### PR TITLE
[Feat] 초기 엔티티 생성 및 연관관계 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
     runtimeOnly("com.h2database:h2")
     // SECURITY
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("io.jsonwebtoken:jjwt-api:0.12.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
     // TEST
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/team/b2/bingojango/BingoJangoApplication.kt
+++ b/src/main/kotlin/team/b2/bingojango/BingoJangoApplication.kt
@@ -2,8 +2,10 @@ package team.b2.bingojango
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
+@EnableJpaAuditing
 class BingoJangoApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/team/b2/bingojango/domain/food/model/Food.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/model/Food.kt
@@ -1,0 +1,32 @@
+package team.b2.bingojango.domain.food.model
+
+import jakarta.persistence.*
+import team.b2.bingojango.domain.groupbuying.model.GroupBuying
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
+import team.b2.bingojango.domain.refrigerator.model.RefrigeratorStatus
+import team.b2.bingojango.global.entity.BaseEntity
+import java.time.ZonedDateTime
+
+@Entity
+@Table(name = "Foods")
+class Food(
+    @Column(name = "category", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val category: RefrigeratorStatus,
+
+    @Column(name = "name", nullable = false)
+    val name: String,
+
+    @Column(name = "expiration_date", nullable = false)
+    val expirationDate: ZonedDateTime,
+
+    @ManyToOne
+    val groupBuying: GroupBuying?,
+
+    @ManyToOne
+    val refrigerator: Refrigerator?
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/food/model/Food.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/model/Food.kt
@@ -21,12 +21,15 @@ class Food(
     val expirationDate: ZonedDateTime,
 
     @ManyToOne
+    @JoinColumn(name = "group_buying_id")
     val groupBuying: GroupBuying?,
 
     @ManyToOne
+    @JoinColumn(name = "refrigerator_id")
     val refrigerator: Refrigerator?
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "food_id", nullable = false)
     val id: Long? = null
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/food/model/FoodCategory.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/model/FoodCategory.kt
@@ -1,0 +1,5 @@
+package team.b2.bingojango.domain.food.model
+
+enum class FoodCategory {
+    FRUIT, VEGETABLE, MEAT, FISH, DESSERT, ICECREAM, DRINK
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/groupbuying/model/GroupBuying.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/groupbuying/model/GroupBuying.kt
@@ -8,9 +8,11 @@ import team.b2.bingojango.global.entity.BaseEntity
 @Table(name = "Group_Buying")
 class GroupBuying(
     @ManyToOne
+    @JoinColumn(name = "refrigerator_id")
     val refrigerator: Refrigerator?
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_buying_id", nullable = false)
     val id: Long? = null
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/groupbuying/model/GroupBuying.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/groupbuying/model/GroupBuying.kt
@@ -1,0 +1,16 @@
+package team.b2.bingojango.domain.groupbuying.model
+
+import jakarta.persistence.*
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
+import team.b2.bingojango.global.entity.BaseEntity
+
+@Entity
+@Table(name = "Group_Buying")
+class GroupBuying(
+    @ManyToOne
+    val refrigerator: Refrigerator?
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/member/model/Member.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/model/Member.kt
@@ -1,0 +1,39 @@
+package team.b2.bingojango.domain.member.model
+
+import jakarta.persistence.*
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
+import team.b2.bingojango.global.entity.BaseEntity
+
+@Entity
+@Table(name = "Members")
+class Member(
+    @Column(name = "role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val role: MemberRole = MemberRole.USER,
+
+    @Column(name = "name", nullable = false)
+    val name: String,
+
+    @Column(name = "nickname", nullable = false)
+    val nickname: String,
+
+    @Column(name = "phone", nullable = false)
+    val phone: String,
+
+    @Column(name = "email", nullable = false)
+    val email: String,
+
+    @Column(name = "password", nullable = false)
+    val password: String,
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val status: MemberStatus,
+
+    @ManyToOne
+    val refrigerator: Refrigerator?
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/member/model/Member.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/model/Member.kt
@@ -31,9 +31,11 @@ class Member(
     val status: MemberStatus,
 
     @ManyToOne
+    @JoinColumn(name = "refrigerator_id")
     val refrigerator: Refrigerator?
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false)
     val id: Long? = null
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/member/model/MemberRole.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/model/MemberRole.kt
@@ -1,0 +1,5 @@
+package team.b2.bingojango.domain.member.model
+
+enum class MemberRole {
+    ADMIN, USER
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/member/model/MemberStatus.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/model/MemberStatus.kt
@@ -1,0 +1,5 @@
+package team.b2.bingojango.domain.member.model
+
+enum class MemberStatus {
+    NORMAL, BANNED, WITHDRAWN
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/refrigerator/model/Refrigerator.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/refrigerator/model/Refrigerator.kt
@@ -1,0 +1,19 @@
+package team.b2.bingojango.domain.refrigerator.model
+
+import jakarta.persistence.*
+import team.b2.bingojango.global.entity.BaseEntity
+
+@Entity
+@Table(name = "Refrigerator")
+class Refrigerator(
+    @Column(name = "name", nullable = false)
+    val name: String,
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val status: RefrigeratorStatus
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/refrigerator/model/Refrigerator.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/refrigerator/model/Refrigerator.kt
@@ -15,5 +15,6 @@ class Refrigerator(
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refrigerator_id", nullable = false)
     val id: Long? = null
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/refrigerator/model/RefrigeratorStatus.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/refrigerator/model/RefrigeratorStatus.kt
@@ -1,0 +1,5 @@
+package team.b2.bingojango.domain.refrigerator.model
+
+enum class RefrigeratorStatus {
+    NORMAL, DELETED
+}

--- a/src/main/kotlin/team/b2/bingojango/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/config/SecurityConfig.kt
@@ -1,0 +1,29 @@
+package team.b2.bingojango.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        return http
+            .httpBasic { it.disable() }
+            .formLogin { it.disable() }
+            .csrf { it.disable() }
+            .cors { it.disable() }
+            .headers { it.frameOptions { foc -> foc.disable() } }
+            .authorizeHttpRequests {
+                it.requestMatchers(
+                    "/h2-console/**",
+                    "/**" // TODO : 추후 삭제
+                ).permitAll()
+                    .anyRequest().authenticated()
+            }
+            .build()
+    }
+}

--- a/src/main/kotlin/team/b2/bingojango/global/entity/BaseEntity.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/entity/BaseEntity.kt
@@ -1,0 +1,26 @@
+package team.b2.bingojango.global.entity
+
+import jakarta.persistence.*
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.ZonedDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity {
+    @Column(name = "created_at", nullable = false, updatable = false)
+    lateinit var createdAt: ZonedDateTime
+
+    @Column(name = "updated_at", nullable = false)
+    lateinit var updatedAt: ZonedDateTime
+
+    @PrePersist
+    fun prePersist() {
+        createdAt = ZonedDateTime.now()
+        updatedAt = ZonedDateTime.now()
+    }
+
+    @PreUpdate
+    fun preUpdate() {
+        updatedAt = ZonedDateTime.now()
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #1 

## 작업 내용

- [ ] Member, Food, Refrigerator, GroupBuying 총 4개의 엔티티 생성 후 연관관계 설정
    - 각 엔티티와 연관된 enum 클래스 생성
- [ ] 모든 엔티티의 공통 속성인 createdAt과 updatedAt을 하나의 BaseEntity로 분리
- [ ] build.gradle에 누락된 Spring Security 관련 의존성 주입
- [ ] Security 관련 설정 파일인 SecurityConfig 파일 생성

## 리뷰 요구사항 (선택)

엔티티 내부 속성과 연관관계는 추후 변경될 수 있습니다.
