### PR TITLE
[Feat] 공동구매 신청 기능 구현

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/food/controller/FoodController.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/controller/FoodController.kt
@@ -1,12 +1,24 @@
 package team.b2.bingojango.domain.food.controller
 
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.b2.bingojango.domain.food.service.FoodService
 
 @RestController
-@RequestMapping("/")
+@RequestMapping("/api/v1/refrigerator/{refrigeratorId}/foods")
 class FoodController(
     private val foodService: FoodService
 ) {
+    @Operation(summary = "특정 식품에 대한 공동구매 신청")
+    @PostMapping("/{foodId}")
+    fun addFoodToPurchase(
+        @PathVariable refrigeratorId: Long,
+        @PathVariable foodId: Long,
+        @RequestParam count: Int
+    ) =
+        foodService.addFoodToPurchase(refrigeratorId, foodId, count)
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/food/model/Food.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/model/Food.kt
@@ -1,7 +1,6 @@
 package team.b2.bingojango.domain.food.model
 
 import jakarta.persistence.*
-import team.b2.bingojango.domain.purchase.model.Purchase
 import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.global.entity.BaseEntity
 import java.time.ZonedDateTime
@@ -18,10 +17,6 @@ class Food(
 
     @Column(name = "expiration_date", nullable = false)
     val expirationDate: ZonedDateTime,
-
-    @ManyToOne
-    @JoinColumn(name = "purchase_id")
-    val purchase: Purchase?,
 
     @ManyToOne
     @JoinColumn(name = "refrigerator_id")

--- a/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
@@ -1,10 +1,52 @@
 package team.b2.bingojango.domain.food.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import team.b2.bingojango.domain.food.repository.FoodRepository
+import team.b2.bingojango.domain.purchase.model.PurchaseStatus
+import team.b2.bingojango.domain.purchase.repository.PurchaseRepository
+import team.b2.bingojango.domain.purchase.service.PurchaseService
+import team.b2.bingojango.domain.purchase_food.model.PurchaseFood
+import team.b2.bingojango.domain.purchase_food.repository.PurchaseFoodRepository
 
 @Service
 class FoodService(
-    private val foodRepository: FoodRepository
+    private val foodRepository: FoodRepository,
+    private val purchaseService: PurchaseService,
+    private val purchaseRepository: PurchaseRepository,
+    private val purchaseFoodRepository: PurchaseFoodRepository
 ) {
+    // [API] 해당 식품을 n개 만큼 공동구매 신청
+    fun addFoodToPurchase(refrigeratorId: Long, foodId: Long, count: Int) =
+        getCurrentPurchase(refrigeratorId).let {
+            checkAlreadyInPurchase() // TODO : 현재 공동구매 진행 중인 식품은 추가할 수 없음을 검증해야 함
+            purchaseFoodRepository.save(
+                PurchaseFood(
+                    count = count,
+                    purchase = it,
+                    food = getFood(foodId)
+                )
+            )
+            "${getFood(foodId).name} ${count}개가 공동구매 신청되었습니다." // TODO: 추후 분리 예정
+        }
+
+    /*
+        [내부 메서드] 현재 진행 중인 Purchase (공동구매)를 리턴
+            - status 가 ON_VOTE (투표 진행중) 인 Purchase 확인
+            - status 가 ON_VOTE (투표 진행중) 인 Purchase 가 없다면, 새로운 Purchase 객체를 생성 후 리턴
+            * TODO : 추후 조회 과정 리팩토링 필요
+     */
+    private fun getCurrentPurchase(refrigeratorId: Long) =
+        purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ON_VOTE }
+            ?: purchaseService.makePurchase(refrigeratorId)
+
+    /*
+        [내부 메서드] 현재 공동구매 진행 중인 식품은 공동구매 목록에 추가할 수 없음을 검증
+            * TODO : 추후 구현 예정
+     */
+    private fun checkAlreadyInPurchase() {}
+
+    // [내부 메서드] id로 Food 객체 가져오기
+    private fun getFood(foodId: Long) =
+        foodRepository.findByIdOrNull(foodId) ?: throw Exception("") // TODO
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/controller/PurchaseController.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/controller/PurchaseController.kt
@@ -1,12 +1,21 @@
 package team.b2.bingojango.domain.purchase.controller
 
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.b2.bingojango.domain.purchase.service.PurchaseService
 
 @RestController
-@RequestMapping("/")
+@RequestMapping("/api/v1/refrigerator/{refrigeratorId}/purchase")
 class PurchaseController(
     private val purchaseService: PurchaseService
 ) {
+    @Operation(summary = "현재 진행 중인 공동구매 목록을 출력")
+    @GetMapping
+    fun showPurchase(
+        @PathVariable refrigeratorId: Long
+    ) =
+        purchaseService.showPurchase(refrigeratorId)
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/model/Purchase.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/model/Purchase.kt
@@ -7,12 +7,9 @@ import team.b2.bingojango.global.entity.BaseEntity
 @Entity
 @Table(name = "Purchase")
 class Purchase(
-    @Column(name = "is_accepted", nullable = false)
-    val isAccepted: Boolean,
-
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    val status: PurchaseStatus,
+    val status: PurchaseStatus = PurchaseStatus.ON_VOTE,
 
     @ManyToOne
     @JoinColumn(name = "refrigerator_id")

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/model/Purchase.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/model/Purchase.kt
@@ -10,6 +10,10 @@ class Purchase(
     @Column(name = "is_accepted", nullable = false)
     val isAccepted: Boolean,
 
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val status: PurchaseStatus,
+
     @ManyToOne
     @JoinColumn(name = "refrigerator_id")
     val refrigerator: Refrigerator?

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/model/PurchaseStatus.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/model/PurchaseStatus.kt
@@ -1,0 +1,5 @@
+package team.b2.bingojango.domain.purchase.model
+
+enum class PurchaseStatus {
+    ON_VOTE, FINISHED, REJECTED
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
@@ -17,24 +17,18 @@ class PurchaseService(
     private val purchaseFoodRepository: PurchaseFoodRepository,
     private val refrigeratorRepository: RefrigeratorRepository
 ) {
-    /*
-        [API] 현재 진행 중인 Purchase 목록을 출력
-            - status 가 ON_VOTE (투표 진행중) 인 Purchase 확인
-            - 현재 Purchase 목록이 없다면 예외 메시지 출력
-            * TODO : 추후 조회 과정 리팩토링 필요
-     */
+
+    // [API] 현재 진행 중인 Purchase 목록을 출력
+    // TODO : 추후 조회 과정 리팩토링 필요
     fun showPurchase(refrigeratorId: Long) =
-        PurchaseFoodResponse.from(
-            purchaseFoodRepository.findAll()
-                .firstOrNull { it.purchase.status == PurchaseStatus.ON_VOTE }
-                ?: throw Exception("") // TODO
-        )
+        purchaseFoodRepository.findAll()
+            .filter { it.purchase.status == PurchaseStatus.ON_VOTE }
+            .map { PurchaseFoodResponse.from(it) }
 
     // [내부 메서드] Purchase 객체 생성 (FoodService > getCurrentPurchase 에서만 사용되는 메서드)
     fun makePurchase(refrigeratorId: Long) =
         purchaseRepository.save(
             Purchase(
-                isAccepted = false,
                 status = PurchaseStatus.ON_VOTE,
                 refrigerator = getRefrigerator(refrigeratorId)
             )

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
@@ -1,10 +1,46 @@
 package team.b2.bingojango.domain.purchase.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.b2.bingojango.domain.purchase.model.Purchase
+import team.b2.bingojango.domain.purchase.model.PurchaseStatus
 import team.b2.bingojango.domain.purchase.repository.PurchaseRepository
+import team.b2.bingojango.domain.purchase_food.dto.response.PurchaseFoodResponse
+import team.b2.bingojango.domain.purchase_food.repository.PurchaseFoodRepository
+import team.b2.bingojango.domain.refrigerator.repository.RefrigeratorRepository
 
 @Service
+@Transactional
 class PurchaseService(
-    private val purchaseRepository: PurchaseRepository
+    private val purchaseRepository: PurchaseRepository,
+    private val purchaseFoodRepository: PurchaseFoodRepository,
+    private val refrigeratorRepository: RefrigeratorRepository
 ) {
+    /*
+        [API] 현재 진행 중인 Purchase 목록을 출력
+            - status 가 ON_VOTE (투표 진행중) 인 Purchase 확인
+            - 현재 Purchase 목록이 없다면 예외 메시지 출력
+            * TODO : 추후 조회 과정 리팩토링 필요
+     */
+    fun showPurchase(refrigeratorId: Long) =
+        PurchaseFoodResponse.from(
+            purchaseFoodRepository.findAll()
+                .firstOrNull { it.purchase.status == PurchaseStatus.ON_VOTE }
+                ?: throw Exception("") // TODO
+        )
+
+    // [내부 메서드] Purchase 객체 생성 (FoodService > getCurrentPurchase 에서만 사용되는 메서드)
+    fun makePurchase(refrigeratorId: Long) =
+        purchaseRepository.save(
+            Purchase(
+                isAccepted = false,
+                status = PurchaseStatus.ON_VOTE,
+                refrigerator = getRefrigerator(refrigeratorId)
+            )
+        )
+
+    // [내부 메서드] id로 Refrigerator 객체 가져오기
+    private fun getRefrigerator(refrigeratorId: Long) =
+        refrigeratorRepository.findByIdOrNull(refrigeratorId) ?: throw Exception("") // TODO
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase_food/dto/response/PurchaseFoodResponse.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase_food/dto/response/PurchaseFoodResponse.kt
@@ -1,0 +1,16 @@
+package team.b2.bingojango.domain.purchase_food.dto.response
+
+import team.b2.bingojango.domain.purchase_food.model.PurchaseFood
+
+data class PurchaseFoodResponse(
+    // TODO : 추후 공동구매를 신청한 회원의 이름도 리턴 예정
+    val foodName: String,
+    val foodCount: Int
+) {
+    companion object {
+        fun from(purchaseFood: PurchaseFood) = PurchaseFoodResponse(
+            foodName = purchaseFood.food.name,
+            foodCount = purchaseFood.count
+        )
+    }
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase_food/model/PurchaseFood.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase_food/model/PurchaseFood.kt
@@ -1,0 +1,25 @@
+package team.b2.bingojango.domain.purchase_food.model
+
+import jakarta.persistence.*
+import team.b2.bingojango.domain.food.model.Food
+import team.b2.bingojango.domain.purchase.model.Purchase
+
+@Entity
+@Table(name = "Purchase_Food")
+class PurchaseFood(
+    @Column(name = "count", nullable = false)
+    val count: Int,
+
+    @ManyToOne
+    @JoinColumn(name = "purchase_id")
+    val purchase: Purchase,
+
+    @ManyToOne
+    @JoinColumn(name = "food_id")
+    val food: Food
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "purchase_food_id")
+    val id: Long? = null
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase_food/repository/PurchaseFoodRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase_food/repository/PurchaseFoodRepository.kt
@@ -1,0 +1,9 @@
+package team.b2.bingojango.domain.purchase_food.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import team.b2.bingojango.domain.purchase_food.model.PurchaseFood
+
+@Repository
+interface PurchaseFoodRepository : JpaRepository<PurchaseFood, Long> {
+}

--- a/src/test/kotlin/team/b2/bingojango/BingoJangoApplicationTests.kt
+++ b/src/test/kotlin/team/b2/bingojango/BingoJangoApplicationTests.kt
@@ -33,7 +33,6 @@ class BingoJangoApplicationTests {
                 category = FoodCategory.FRUIT,
                 name = "사과",
                 expirationDate = ZonedDateTime.now().plusDays(7),
-                purchase = null,
                 refrigerator = refrigeratorRepository.findByIdOrNull(1) ?: throw Exception("")
             )
         )
@@ -43,7 +42,6 @@ class BingoJangoApplicationTests {
                 category = FoodCategory.DRINK,
                 name = "우유",
                 expirationDate = ZonedDateTime.now().plusDays(3),
-                purchase = null,
                 refrigerator = refrigeratorRepository.findByIdOrNull(1) ?: throw Exception("")
             )
         )


### PR DESCRIPTION
## 연관된 이슈

- closes #11 

## 작업 내용

- [ ] Food랑 Purchase 간의 연관관계를 다대다 관계로 변경 (기존: 1:n 단방향 관계)
- [ ] Food와 Purchase 간의 다대다 관계를 풀어줄 PurchaseFood 테이블 생성
    - PurchaseFood의 Repository 인터페이스와 Response 객체 생성 
- [ ] FoodController와 FoodService에 addFoodToPurchase(특정 식품에 대한 공동구매 신청) 메서드 생성
    - FoodService 내에서 현재 진행 중인 Purchase를 리턴하는 getCurrentPurchase 메서드 생성
    - 현재 진행 중인 Purchase가 없다면 새로운 Purchase 객체를 생성 (PurchaseService > makePurchase 메서드)
- [ ] PurchaseController와 PurchaseService에 showPurchase(현재 진행 중인 Purchase 목록 출력) 메서드 생성
- [ ] Purchase의 상태를 판단하는 PurchaseStatus Enum클래스 생성
    - ON_VOTE (공동구매 진행), FINISHED (공동구매 종료), REJECTED (거절된 공동구매)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
