### PR TITLE
[Refactor] User-Refrigerator 엔티티 간 연관관계 재설정

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/member/model/Member.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/model/Member.kt
@@ -1,0 +1,26 @@
+package team.b2.bingojango.domain.member.model
+
+import jakarta.persistence.*
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
+import team.b2.bingojango.domain.user.model.User
+
+@Entity
+@Table(name = "Members")
+class Member(
+    @Column(name = "role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val role: MemberRole,
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    val user: User,
+
+    @ManyToOne
+    @JoinColumn(name = "refrigerator_id")
+    val refrigerator: Refrigerator
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false)
+    val id: Long? = null
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/member/model/MemberRole.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/model/MemberRole.kt
@@ -1,5 +1,5 @@
 package team.b2.bingojango.domain.member.model
 
-enum class UserRole {
-    ADMIN, USER
+enum class MemberRole {
+    STAFF, MEMBER
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/repository/MemberRepository.kt
@@ -2,10 +2,8 @@ package team.b2.bingojango.domain.member.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import team.b2.bingojango.domain.member.model.User
+import team.b2.bingojango.domain.member.model.Member
 
 @Repository
-interface UserRepository : JpaRepository<User, Long> {
-
-    fun findByEmail(email:String) : User?
+interface MemberRepository : JpaRepository<Member, Long> {
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/controller/UserController.kt
@@ -1,4 +1,4 @@
-package team.b2.bingojango.domain.member.controller
+package team.b2.bingojango.domain.user.controller
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -7,9 +7,9 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import team.b2.bingojango.domain.member.dto.LoginRequest
-import team.b2.bingojango.domain.member.dto.LoginResponse
-import team.b2.bingojango.domain.member.service.UserService
+import team.b2.bingojango.domain.user.dto.LoginRequest
+import team.b2.bingojango.domain.user.dto.LoginResponse
+import team.b2.bingojango.domain.user.service.UserService
 
 
 @RestController

--- a/src/main/kotlin/team/b2/bingojango/domain/user/dto/LoginRequest.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/dto/LoginRequest.kt
@@ -1,4 +1,4 @@
-package team.b2.bingojango.domain.member.dto
+package team.b2.bingojango.domain.user.dto
 
 data class LoginRequest (
     val email: String,

--- a/src/main/kotlin/team/b2/bingojango/domain/user/dto/LoginResponse.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/dto/LoginResponse.kt
@@ -1,4 +1,4 @@
-package team.b2.bingojango.domain.member.dto
+package team.b2.bingojango.domain.user.dto
 
 data class LoginResponse (
     val accessToken: String

--- a/src/main/kotlin/team/b2/bingojango/domain/user/model/User.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/model/User.kt
@@ -1,7 +1,6 @@
-package team.b2.bingojango.domain.member.model
+package team.b2.bingojango.domain.user.model
 
 import jakarta.persistence.*
-import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.global.entity.BaseEntity
 
 @Entity
@@ -28,11 +27,7 @@ class User(
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    val status: UserStatus,
-
-    @ManyToOne
-    @JoinColumn(name = "refrigerator_id")
-    val refrigerator: Refrigerator?
+    val status: UserStatus
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/team/b2/bingojango/domain/user/model/UserRole.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/model/UserRole.kt
@@ -1,0 +1,5 @@
+package team.b2.bingojango.domain.user.model
+
+enum class UserRole {
+    ADMIN, USER
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/user/model/UserStatus.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/model/UserStatus.kt
@@ -1,4 +1,4 @@
-package team.b2.bingojango.domain.member.model
+package team.b2.bingojango.domain.user.model
 
 enum class UserStatus {
     NORMAL, BANNED, WITHDRAWN

--- a/src/main/kotlin/team/b2/bingojango/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/repository/UserRepository.kt
@@ -1,0 +1,11 @@
+package team.b2.bingojango.domain.user.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import team.b2.bingojango.domain.user.model.User
+
+@Repository
+interface UserRepository : JpaRepository<User, Long> {
+
+    fun findByEmail(email:String) : User?
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/user/service/UserService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/service/UserService.kt
@@ -1,10 +1,10 @@
-package team.b2.bingojango.domain.member.service
+package team.b2.bingojango.domain.user.service
 
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
-import team.b2.bingojango.domain.member.dto.LoginRequest
-import team.b2.bingojango.domain.member.dto.LoginResponse
-import team.b2.bingojango.domain.member.repository.UserRepository
+import team.b2.bingojango.domain.user.dto.LoginRequest
+import team.b2.bingojango.domain.user.dto.LoginResponse
+import team.b2.bingojango.domain.user.repository.UserRepository
 import team.b2.bingojango.global.exception.InvalidCredentialException
 import team.b2.bingojango.global.security.jwt.JwtPlugin
 


### PR DESCRIPTION
## 연관된 이슈

- closes #18 

## 작업 내용

- [ ] 애플리케이션에 가입한 '회원'을 지칭하는 엔티티의 이름을 User로 수정 (기존 엔티티명: Member)
    - 패키지 명을 member에서 user로 변경
- [ ] User와 Refrigerator의 관계를 다대다 관계로 수정
    - User와 Refrigerator 사이에 Member라는 중간 엔티티를 두고 각 엔티티와 일대다 관계로 연결
- [ ] Member의 권한을 결정하는 MemberRole enum 클래스 생성 (STAFF, MEMBER)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
