### PR TITLE
[BugFix] Product를 Purchase에 저장하는 과정에서 발생하는 오류 수정

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
@@ -5,19 +5,25 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.b2.bingojango.domain.food.repository.FoodRepository
 import team.b2.bingojango.domain.product.model.Product
+import team.b2.bingojango.domain.product.repository.ProductRepository
+import team.b2.bingojango.domain.product.service.ProductService
 import team.b2.bingojango.domain.purchase.model.PurchaseStatus
 import team.b2.bingojango.domain.purchase.repository.PurchaseRepository
 import team.b2.bingojango.domain.purchase.service.PurchaseService
 import team.b2.bingojango.domain.purchase_product.model.PurchaseProduct
 import team.b2.bingojango.domain.purchase_product.repository.PurchaseProductRepository
+import team.b2.bingojango.domain.refrigerator.repository.RefrigeratorRepository
 
 @Service
 @Transactional
 class FoodService(
     private val foodRepository: FoodRepository,
+    private val productService: ProductService,
+    private val productRepository: ProductRepository,
     private val purchaseService: PurchaseService,
     private val purchaseRepository: PurchaseRepository,
-    private val purchaseProductRepository: PurchaseProductRepository
+    private val purchaseProductRepository: PurchaseProductRepository,
+    private val refrigeratorRepository: RefrigeratorRepository
 ) {
     // [API] 해당 식품을 n개 만큼 공동구매 신청
     fun addFoodToPurchase(refrigeratorId: Long, foodId: Long, count: Int) =
@@ -27,7 +33,7 @@ class FoodService(
                 PurchaseProduct(
                     count = count,
                     purchase = it,
-                    product = Product(getFood(foodId)) // TODO : 추후에 연관관계에 따른 별도의 객체 생성 로직 필요
+                    product = getProduct(foodId, refrigeratorId)
                 )
             )
             "${getFood(foodId).name} ${count}개가 공동구매 신청되었습니다." // TODO: 추후 분리 예정
@@ -41,7 +47,16 @@ class FoodService(
      */
     private fun getCurrentPurchase(refrigeratorId: Long) =
         purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ON_VOTE }
-            ?: purchaseService.makePurchase(refrigeratorId)
+            ?: purchaseService.makePurchase(getRefrigerator(refrigeratorId))
+
+    /*
+        [내부 메서드] 현재 냉장고에 해당 식품이 Product (상품)으로 등록되어 있는지 여부를 확인
+            - food 와 refrigerator 객체를 활용해 해당 Product 를 조회하고, 그대로 리턴
+            - 해당 Product 가 없다면, 새로운 Product 객체를 생성 후 리턴
+     */
+    private fun getProduct(foodId: Long, refrigeratorId: Long): Product =
+        productRepository.findByFoodAndRefrigerator(getFood(foodId), getRefrigerator(refrigeratorId))
+            ?: productService.addProduct(getFood(foodId), getRefrigerator(refrigeratorId))
 
     /*
         [내부 메서드] 현재 공동구매 진행 중인 식품은 공동구매 목록에 추가할 수 없음을 검증
@@ -52,4 +67,8 @@ class FoodService(
     // [내부 메서드] id로 Food 객체 가져오기
     private fun getFood(foodId: Long) =
         foodRepository.findByIdOrNull(foodId) ?: throw Exception("") // TODO
+
+    // [내부 메서드] id로 Refrigerator 객체 가져오기
+    private fun getRefrigerator(refrigeratorId: Long) =
+        refrigeratorRepository.findByIdOrNull(refrigeratorId) ?: throw Exception("") // TODO
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/product/model/Product.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/product/model/Product.kt
@@ -2,13 +2,18 @@ package team.b2.bingojango.domain.product.model
 
 import jakarta.persistence.*
 import team.b2.bingojango.domain.food.model.Food
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 
 @Entity
 @Table(name = "Products")
 class Product(
     @OneToOne
     @JoinColumn(name = "food_id")
-    val food: Food
+    val food: Food,
+
+    @ManyToOne
+    @JoinColumn(name = "refrigerator_id")
+    val refrigerator: Refrigerator
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/team/b2/bingojango/domain/product/repository/ProductRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/product/repository/ProductRepository.kt
@@ -2,8 +2,11 @@ package team.b2.bingojango.domain.product.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import team.b2.bingojango.domain.food.model.Food
 import team.b2.bingojango.domain.product.model.Product
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 
 @Repository
 interface ProductRepository : JpaRepository<Product, Long> {
+    fun findByFoodAndRefrigerator(food: Food, refrigerator: Refrigerator): Product?
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/product/service/ProductService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/product/service/ProductService.kt
@@ -1,0 +1,20 @@
+package team.b2.bingojango.domain.product.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.b2.bingojango.domain.food.model.Food
+import team.b2.bingojango.domain.product.model.Product
+import team.b2.bingojango.domain.product.repository.ProductRepository
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
+
+@Service
+@Transactional
+class ProductService(
+    private val productRepository: ProductRepository
+) {
+    // [내부 메서드] Product 객체 생성 (FoodService > getProduct 에서만 사용되는 메서드)
+    fun addProduct(food: Food, refrigerator: Refrigerator) =
+        productRepository.save(
+            Product(food = food, refrigerator = refrigerator)
+        )
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
@@ -8,6 +8,7 @@ import team.b2.bingojango.domain.purchase.model.PurchaseStatus
 import team.b2.bingojango.domain.purchase.repository.PurchaseRepository
 import team.b2.bingojango.domain.purchase_product.dto.response.PurchaseProductResponse
 import team.b2.bingojango.domain.purchase_product.repository.PurchaseProductRepository
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.domain.refrigerator.repository.RefrigeratorRepository
 
 @Service
@@ -26,15 +27,11 @@ class PurchaseService(
             .map { PurchaseProductResponse.from(it) }
 
     // [내부 메서드] Purchase 객체 생성 (FoodService > getCurrentPurchase 에서만 사용되는 메서드)
-    fun makePurchase(refrigeratorId: Long) =
+    fun makePurchase(refrigerator: Refrigerator) =
         purchaseRepository.save(
             Purchase(
                 status = PurchaseStatus.ON_VOTE,
-                refrigerator = getRefrigerator(refrigeratorId)
+                refrigerator = refrigerator
             )
         )
-
-    // [내부 메서드] id로 Refrigerator 객체 가져오기
-    private fun getRefrigerator(refrigeratorId: Long) =
-        refrigeratorRepository.findByIdOrNull(refrigeratorId) ?: throw Exception("") // TODO
 }


### PR DESCRIPTION
## 연관된 이슈

- closes #24 

## 작업 내용

- [ ] Product 엔티티에 누락된 Refrigerator 속성 추가 (ManyToOne)
- [ ] FoodService 내부에 Product 객체를 가져오는 getProduct 메서드 생성
    - DB에 foodId와 refrigeratorId가 일치하는 경우 굳이 새로 Product 객체를 생성하지 않고 기존 객체 재활용
    - DB에 foodId와 refrigeratorId가 일치하는 Product가 없는 경우 새로운 Product 객체 생성
    - ProductService에 새로운 Product 객체를 생성해 저장하는 addProduct 메서드 생성

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
