### PR TITLE
[Feat] 투표 시작 및 투표 기능 구현

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
@@ -41,12 +41,12 @@ class FoodService(
 
     /*
         [내부 메서드] 현재 진행 중인 Purchase (공동구매)를 리턴
-            - status 가 ON_VOTE (투표 진행중) 인 Purchase 확인
-            - status 가 ON_VOTE (투표 진행중) 인 Purchase 가 없다면, 새로운 Purchase 객체를 생성 후 리턴
+            - status 가 ACTIVE (활성화) 인 Purchase 확인
+            - status 가 ACTIVE (활성화) 인 Purchase 가 없다면, 새로운 Purchase 객체를 생성 후 리턴
             * TODO : 추후 조회 과정 리팩토링 필요
      */
     private fun getCurrentPurchase(refrigeratorId: Long) =
-        purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ON_VOTE }
+        purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ACTIVE }
             ?: purchaseService.makePurchase(getRefrigerator(refrigeratorId))
 
     /*

--- a/src/main/kotlin/team/b2/bingojango/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/repository/MemberRepository.kt
@@ -3,7 +3,11 @@ package team.b2.bingojango.domain.member.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import team.b2.bingojango.domain.member.model.Member
+import team.b2.bingojango.domain.member.model.MemberRole
+import team.b2.bingojango.domain.user.model.User
 
 @Repository
 interface MemberRepository : JpaRepository<Member, Long> {
+    fun countByRole(role: MemberRole): Long
+    fun findByUser(user: User): Member?
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/controller/PurchaseController.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/controller/PurchaseController.kt
@@ -1,11 +1,19 @@
 package team.b2.bingojango.domain.purchase.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.b2.bingojango.domain.purchase.service.PurchaseService
+import team.b2.bingojango.domain.vote.dto.request.VoteRequest
+import team.b2.bingojango.global.security.UserPrincipal
 
 @RestController
 @RequestMapping("/api/v1/refrigerator/{refrigeratorId}/purchase")
@@ -18,4 +26,23 @@ class PurchaseController(
         @PathVariable refrigeratorId: Long
     ) =
         purchaseService.showPurchase(refrigeratorId)
+
+    @Operation(summary = "현재 공동구매 목록에 대한 투표 시작")
+    @PostMapping("/vote")
+    fun startVote(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable refrigeratorId: Long,
+        @RequestBody voteRequest: VoteRequest
+    ) =
+        ResponseEntity.ok().body(purchaseService.startVote(userPrincipal, refrigeratorId, voteRequest))
+
+    @Operation(summary = "현재 공동구매 목록에 대한 투표")
+    @PutMapping("/vote/{voteId}")
+    fun vote(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable refrigeratorId: Long,
+        @PathVariable voteId: Long,
+        @RequestParam isAccepted: Boolean
+    ) =
+        ResponseEntity.ok().body(purchaseService.vote(userPrincipal, refrigeratorId, voteId, isAccepted))
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/controller/PurchaseController.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/controller/PurchaseController.kt
@@ -1,6 +1,7 @@
 package team.b2.bingojango.domain.purchase.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -20,7 +21,7 @@ import team.b2.bingojango.global.security.UserPrincipal
 class PurchaseController(
     private val purchaseService: PurchaseService
 ) {
-    @Operation(summary = "현재 진행 중인 공동구매 목록을 출력")
+    @Operation(summary = "현재 공동구매 목록을 출력")
     @GetMapping
     fun showPurchase(
         @PathVariable refrigeratorId: Long
@@ -32,7 +33,7 @@ class PurchaseController(
     fun startVote(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PathVariable refrigeratorId: Long,
-        @RequestBody voteRequest: VoteRequest
+        @Valid @RequestBody voteRequest: VoteRequest
     ) =
         ResponseEntity.ok().body(purchaseService.startVote(userPrincipal, refrigeratorId, voteRequest))
 

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/model/Purchase.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/model/Purchase.kt
@@ -9,7 +9,7 @@ import team.b2.bingojango.global.entity.BaseEntity
 class Purchase(
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    val status: PurchaseStatus = PurchaseStatus.ON_VOTE,
+    var status: PurchaseStatus = PurchaseStatus.ACTIVE,
 
     @ManyToOne
     @JoinColumn(name = "refrigerator_id")
@@ -19,4 +19,8 @@ class Purchase(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "purchase_id", nullable = false)
     val id: Long? = null
+
+    fun updateStatus(status: PurchaseStatus) {
+        this.status = status
+    }
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/model/PurchaseStatus.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/model/PurchaseStatus.kt
@@ -1,5 +1,5 @@
 package team.b2.bingojango.domain.purchase.model
 
 enum class PurchaseStatus {
-    ON_VOTE, FINISHED, REJECTED
+    ACTIVE, FINISHED, REJECTED
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
@@ -3,6 +3,8 @@ package team.b2.bingojango.domain.purchase.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.b2.bingojango.domain.member.model.MemberRole
+import team.b2.bingojango.domain.member.repository.MemberRepository
 import team.b2.bingojango.domain.purchase.model.Purchase
 import team.b2.bingojango.domain.purchase.model.PurchaseStatus
 import team.b2.bingojango.domain.purchase.repository.PurchaseRepository
@@ -10,28 +12,91 @@ import team.b2.bingojango.domain.purchase_product.dto.response.PurchaseProductRe
 import team.b2.bingojango.domain.purchase_product.repository.PurchaseProductRepository
 import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.domain.refrigerator.repository.RefrigeratorRepository
+import team.b2.bingojango.domain.user.repository.UserRepository
+import team.b2.bingojango.domain.vote.dto.request.VoteRequest
+import team.b2.bingojango.domain.vote.model.Vote
+import team.b2.bingojango.domain.vote.repository.VoteRepository
+import team.b2.bingojango.global.security.UserPrincipal
 
 @Service
 @Transactional
 class PurchaseService(
+    private val userRepository: UserRepository,
+    private val memberRepository: MemberRepository,
     private val purchaseRepository: PurchaseRepository,
     private val purchaseProductRepository: PurchaseProductRepository,
+    private val voteRepository: VoteRepository,
     private val refrigeratorRepository: RefrigeratorRepository
 ) {
-
     // [API] 현재 진행 중인 Purchase 목록을 출력
     // TODO : 추후 조회 과정 리팩토링 필요
     fun showPurchase(refrigeratorId: Long) =
         purchaseProductRepository.findAll()
-            .filter { it.purchase.status == PurchaseStatus.ON_VOTE }
+            .filter { it.purchase.status == PurchaseStatus.ACTIVE }
             .map { PurchaseProductResponse.from(it) }
+
+    // [API] 현재 공동구매 목록에 대한 투표 시작
+    fun startVote(userPrincipal: UserPrincipal, refrigeratorId: Long, voteRequest: VoteRequest) =
+        getMember(userPrincipal.id).let {
+            voteRepository.save(
+                voteRequest.to(
+                    request = voteRequest,
+                    refrigerator = getRefrigerator(refrigeratorId),
+                    member = it
+                )
+            )
+        }
+
+    /*
+        [API] 투표 실시
+            - 찬성인 경우, voters 에 해당 Member 객체를 add
+            - 만장일치가 완성된 경우, 투표를 종료하고 현재 ACTIVE 상태의 Purchase 를 FINISHED 로 변경
+            - 반대가 하나라도 있는 경우, 투표를 종료하고 현재 ACTIVE 상태의 Purchase 를 REJECTED 로 변경
+            * TODO : 해당 멤버가 투표 권한이 있는지 확인
+     */
+    fun vote(userPrincipal: UserPrincipal, refrigeratorId: Long, voteId: Long, isAccepted: Boolean) {
+        getVote(voteId).let {
+            if (isAccepted) {
+                it.vote(getMember(userPrincipal.id))
+                if (isCompletedVote(it))
+                    getCurrentPurchase(refrigeratorId).updateStatus(PurchaseStatus.FINISHED)
+            } else
+                getCurrentPurchase(refrigeratorId).updateStatus(PurchaseStatus.REJECTED)
+        }
+    }
+
+    // [내부 메서드] 만장일치를 받았는지 확인 (냉장고 내 관리자의 수 == 찬성한 인원 수)
+    private fun isCompletedVote(vote: Vote) =
+        memberRepository.countByRole(MemberRole.STAFF) == vote.voters.size.toLong()
 
     // [내부 메서드] Purchase 객체 생성 (FoodService > getCurrentPurchase 에서만 사용되는 메서드)
     fun makePurchase(refrigerator: Refrigerator) =
         purchaseRepository.save(
             Purchase(
-                status = PurchaseStatus.ON_VOTE,
+                status = PurchaseStatus.ACTIVE,
                 refrigerator = refrigerator
             )
         )
+
+    /*
+    [내부 메서드] 현재 진행 중인 Purchase (공동구매)를 리턴
+        - status 가 ACTIVE (투표 진행중) 인 Purchase 확인
+        - status 가 ACTIVE (투표 진행중) 인 Purchase 가 없다면, 새로운 Purchase 객체를 생성 후 리턴
+        * TODO : 추후 조회 과정 리팩토링 필요
+    */
+    private fun getCurrentPurchase(refrigeratorId: Long) =
+        purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ACTIVE }
+            ?: makePurchase(getRefrigerator(refrigeratorId))
+
+    private fun getVote(voteId: Long) =
+        voteRepository.findByIdOrNull(voteId) ?: throw Exception("") // TODO
+
+    private fun getMember(userId: Long) =
+        memberRepository.findByUser(getUser(userId)) ?: throw Exception("") // TODO
+
+    private fun getUser(userId: Long) =
+        userRepository.findByIdOrNull(userId) ?: throw Exception("") // TODO
+
+    private fun getRefrigerator(refrigeratorId: Long) =
+        refrigeratorRepository.findByIdOrNull(refrigeratorId) ?: throw Exception("") // TODO
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/user/model/User.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/model/User.kt
@@ -27,7 +27,7 @@ class User(
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    val status: UserStatus
+    val status: UserStatus = UserStatus.NORMAL
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/team/b2/bingojango/domain/user/model/User.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/model/User.kt
@@ -27,7 +27,7 @@ class User(
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    val status: UserStatus = UserStatus.NORMAL
+    var status: UserStatus = UserStatus.NORMAL
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/dto/request/VoteRequest.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/dto/request/VoteRequest.kt
@@ -1,5 +1,7 @@
 package team.b2.bingojango.domain.vote.dto.request
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
 import team.b2.bingojango.domain.member.model.Member
 import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.domain.vote.model.Vote
@@ -7,11 +9,17 @@ import team.b2.bingojango.global.util.ZonedDateTimeConverter
 
 data class VoteRequest(
     val description: String?,
+
+    @field:NotBlank(message = "투표 마감 시간은 필수 입력 사항입니다.")
+    @field:Pattern(
+        regexp = "\\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]) ([0-1][0-9]|2[0-3]):([0-5][0-9])",
+        message = "투표 마감 시간을 다시 한 번 확인해주세요. (yyyy-MM-dd HH:mm)"
+    )
     val dueDate: String,
 ) {
     fun to(request: VoteRequest, refrigerator: Refrigerator, member: Member) = Vote(
         description = request.description,
-        dueDate = ZonedDateTimeConverter.convertStringDateFromZonedDateTime(request.dueDate),
+        dueDate = ZonedDateTimeConverter.convertStringDateTimeFromZonedDateTime(request.dueDate),
         refrigerator = refrigerator,
         voters = mutableSetOf(member)
     )

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/dto/request/VoteRequest.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/dto/request/VoteRequest.kt
@@ -1,0 +1,18 @@
+package team.b2.bingojango.domain.vote.dto.request
+
+import team.b2.bingojango.domain.member.model.Member
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
+import team.b2.bingojango.domain.vote.model.Vote
+import team.b2.bingojango.global.util.ZonedDateTimeConverter
+
+data class VoteRequest(
+    val description: String?,
+    val dueDate: String,
+) {
+    fun to(request: VoteRequest, refrigerator: Refrigerator, member: Member) = Vote(
+        description = request.description,
+        dueDate = ZonedDateTimeConverter.convertStringDateFromZonedDateTime(request.dueDate),
+        refrigerator = refrigerator,
+        voters = mutableSetOf(member)
+    )
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/dto/response/VoteResponse.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/dto/response/VoteResponse.kt
@@ -1,0 +1,20 @@
+package team.b2.bingojango.domain.vote.dto.response
+
+import team.b2.bingojango.domain.vote.model.Vote
+import team.b2.bingojango.global.util.ZonedDateTimeConverter
+
+data class VoteResponse(
+    val description: String,
+    val dueDate: String,
+    val memberName: String,
+    val voteStatus: String
+) {
+    companion object {
+        fun from(vote: Vote, numberOfStaff: Long) = VoteResponse(
+            description = vote.description ?: "",
+            dueDate = ZonedDateTimeConverter.convertZonedDateTimeFromStringDateTime(vote.dueDate),
+            memberName = "", // TODO
+            voteStatus = "투표 현황: 찬성 ${vote.voters.size}명 / ${numberOfStaff}명"
+        )
+    }
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/model/Vote.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/model/Vote.kt
@@ -1,0 +1,32 @@
+package team.b2.bingojango.domain.vote.model
+
+import jakarta.persistence.*
+import team.b2.bingojango.domain.member.model.Member
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
+import team.b2.bingojango.global.entity.BaseEntity
+import java.time.ZonedDateTime
+
+@Entity
+@Table(name = "Votes")
+class Vote(
+    @Column(name = "description", nullable = true)
+    val description: String?,
+
+    @Column(name = "due_date", nullable = false)
+    val dueDate: ZonedDateTime,
+
+    @ManyToOne
+    val refrigerator: Refrigerator,
+
+    @ManyToMany
+    val voters: MutableSet<Member> = mutableSetOf()
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "food_id", nullable = false)
+    val id: Long? = null
+
+    fun vote(member: Member) {
+        voters.add(member)
+    }
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/repository/VoteRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/repository/VoteRepository.kt
@@ -1,0 +1,9 @@
+package team.b2.bingojango.domain.vote.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import team.b2.bingojango.domain.vote.model.Vote
+
+@Repository
+interface VoteRepository : JpaRepository<Vote, Long> {
+}

--- a/src/main/kotlin/team/b2/bingojango/global/util/ZonedDateTimeConverter.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/util/ZonedDateTimeConverter.kt
@@ -6,6 +6,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 object ZonedDateTimeConverter {
+    // String 날짜 데이터 -> ZonedDateTime 날짜+시간 데이터
     fun convertStringDateFromZonedDateTime(date: String): ZonedDateTime =
         ZonedDateTime.of(
             LocalDate.parse(
@@ -13,5 +14,21 @@ object ZonedDateTimeConverter {
                 DateTimeFormatter.ofPattern("yyyy-MM-dd")
             ).atStartOfDay(),
             ZoneId.of("Asia/Seoul")
+        )
+
+    // String 날짜+시간 데이터 -> ZonedDateTime 날짜+시간 데이터
+    fun convertStringDateTimeFromZonedDateTime(dateTime: String): ZonedDateTime =
+        ZonedDateTime.of(
+            LocalDate.parse(
+                dateTime,
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+            ).atStartOfDay(),
+            ZoneId.of("Asia/Seoul")
+        )
+
+    // ZonedDateTime 날짜+시간 데이터 -> String 날짜+시간 데이터
+    fun convertZonedDateTimeFromStringDateTime(dateTime: ZonedDateTime): String =
+        dateTime.format(
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
         )
 }

--- a/src/main/kotlin/team/b2/bingojango/global/util/ZonedDateTimeConverter.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/util/ZonedDateTimeConverter.kt
@@ -1,0 +1,17 @@
+package team.b2.bingojango.global.util
+
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+object ZonedDateTimeConverter {
+    fun convertStringDateFromZonedDateTime(date: String): ZonedDateTime =
+        ZonedDateTime.of(
+            LocalDate.parse(
+                date,
+                DateTimeFormatter.ofPattern("yyyy-MM-dd")
+            ).atStartOfDay(),
+            ZoneId.of("Asia/Seoul")
+        )
+}

--- a/src/test/kotlin/team/b2/bingojango/BingoJangoApplicationTests.kt
+++ b/src/test/kotlin/team/b2/bingojango/BingoJangoApplicationTests.kt
@@ -4,20 +4,45 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.crypto.password.PasswordEncoder
 import team.b2.bingojango.domain.food.model.Food
 import team.b2.bingojango.domain.food.model.FoodCategory
 import team.b2.bingojango.domain.food.repository.FoodRepository
 import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.domain.refrigerator.repository.RefrigeratorRepository
+import team.b2.bingojango.domain.user.model.User
+import team.b2.bingojango.domain.user.model.UserStatus
+import team.b2.bingojango.domain.user.repository.UserRepository
 import java.time.ZonedDateTime
 
 @SpringBootTest
 class BingoJangoApplicationTests {
     @Autowired
+    lateinit var passwordEncoder: PasswordEncoder
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    @Autowired
     lateinit var foodRepository: FoodRepository
 
     @Autowired
     lateinit var refrigeratorRepository: RefrigeratorRepository
+
+    @Test
+    fun 유저임시등록() {
+        userRepository.save(
+            User(
+                name = "허훈",
+                nickname = "hun819",
+                phone = "010-2939-8746",
+                email = "hunzz.study@gmail.com",
+                password = passwordEncoder.encode("1234"),
+                status = UserStatus.NORMAL
+            )
+        )
+
+    }
 
     @Test
     fun 냉장고임시등록() {


### PR DESCRIPTION
## 연관된 이슈

- closes #30 

## 작업 내용

- [ ] Vote 엔티티를 생성하고, Member와 다대다 관계로 연결
    - VoteRequest 클래스와 VoteRepository 인터페이스 생성
    - 찬성표를 던진 Member를 MutableSet 자료구조에 담아서 관리
- [ ] PurchaseController와 PurchaseService에 startVote(투표 시작) 메서드 생성
- [ ] PurchaseController와 PurchaseService에 vote(투표) 메서드 생성
    - PurchaseService 내에 해당 투표의 만장일치를 확인하는 isCompletedVote 내부 메서드 생성
    - 냉장고 내 관리자 수와 현재 찬성표를 던진 관리자의 수가 일치하는 경우 만장일치로 판별
    - 만장일치가 완성된 경우, 투표를 종료하고 Purchase의 status를 FINISHED로 변경
    - 반대표가 하나라도 존재하는 경우, 투표를 종료하고 Purchase의 status를 REJECTED로 변경
- [ ] PurchaseStatus의 ON_VOTE(투표중)를 ACTIVE(활성화)로 설정하여 의미를 직관적으로 표현
- [ ] ZonedDateTimeConverter Object를 생성하여 문자열의 날짜 데이터를 ZonedDateTime으로 변환하는 기능 구현

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
