### PR TITLE
[Refactor] Purchase 관련 클래스 코드 리팩토링

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
@@ -5,11 +5,12 @@ import org.springframework.transaction.annotation.Transactional
 import team.b2.bingojango.domain.product.model.Product
 import team.b2.bingojango.domain.product.repository.ProductRepository
 import team.b2.bingojango.domain.product.service.ProductService
+import team.b2.bingojango.domain.purchase.model.Purchase
 import team.b2.bingojango.domain.purchase.model.PurchaseStatus
 import team.b2.bingojango.domain.purchase.repository.PurchaseRepository
-import team.b2.bingojango.domain.purchase.service.PurchaseService
 import team.b2.bingojango.domain.purchase_product.model.PurchaseProduct
 import team.b2.bingojango.domain.purchase_product.repository.PurchaseProductRepository
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.global.security.UserPrincipal
 import team.b2.bingojango.global.util.EntityFinder
 
@@ -18,7 +19,6 @@ import team.b2.bingojango.global.util.EntityFinder
 class FoodService(
     private val productService: ProductService,
     private val productRepository: ProductRepository,
-    private val purchaseService: PurchaseService,
     private val purchaseRepository: PurchaseRepository,
     private val purchaseProductRepository: PurchaseProductRepository,
     private val entityFinder: EntityFinder
@@ -37,15 +37,20 @@ class FoodService(
             "${entityFinder.getFood(foodId).name} ${count}개가 공동구매 신청되었습니다." // TODO: 추후 분리 예정
         }
 
-    /*
-        [내부 메서드] 현재 진행 중인 Purchase (공동구매)를 리턴
-            - status 가 ACTIVE (활성화) 인 Purchase 확인
-            - status 가 ACTIVE (활성화) 인 Purchase 가 없다면, 새로운 Purchase 객체를 생성 후 리턴
-            * TODO : 추후 조회 과정 리팩토링 필요
-     */
+    // [내부 메서드] 현재 진행 중인(status 가 ACTIVE 한) Purchase 를 리턴 (없으면 새로운 Purchase 객체 생성 후 리턴)
     private fun getCurrentPurchase(userPrincipal: UserPrincipal, refrigeratorId: Long) =
         purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ACTIVE }
-            ?: purchaseService.makePurchase(userPrincipal, entityFinder.getRefrigerator(refrigeratorId))
+            ?: makePurchase(userPrincipal, entityFinder.getRefrigerator(refrigeratorId))
+
+    // [내부 메서드] Purchase 객체 생성
+    private fun makePurchase(userPrincipal: UserPrincipal, refrigerator: Refrigerator) =
+        purchaseRepository.save(
+            Purchase(
+                status = PurchaseStatus.ACTIVE,
+                proposedBy = userPrincipal.id,
+                refrigerator = refrigerator
+            )
+        )
 
     /*
         [내부 메서드] 현재 냉장고에 해당 식품이 Product (상품)으로 등록되어 있는지 여부를 확인
@@ -63,5 +68,7 @@ class FoodService(
         [내부 메서드] 현재 공동구매 진행 중인 식품은 공동구매 목록에 추가할 수 없음을 검증
             * TODO : 추후 구현 예정
      */
-    private fun checkAlreadyInPurchase() {}
+    private fun checkAlreadyInPurchase() {
+//        if (getCurrentPurchase())
+    }
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
@@ -1,9 +1,7 @@
 package team.b2.bingojango.domain.food.service
 
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.b2.bingojango.domain.food.repository.FoodRepository
 import team.b2.bingojango.domain.product.model.Product
 import team.b2.bingojango.domain.product.repository.ProductRepository
 import team.b2.bingojango.domain.product.service.ProductService
@@ -12,19 +10,18 @@ import team.b2.bingojango.domain.purchase.repository.PurchaseRepository
 import team.b2.bingojango.domain.purchase.service.PurchaseService
 import team.b2.bingojango.domain.purchase_product.model.PurchaseProduct
 import team.b2.bingojango.domain.purchase_product.repository.PurchaseProductRepository
-import team.b2.bingojango.domain.refrigerator.repository.RefrigeratorRepository
 import team.b2.bingojango.global.security.UserPrincipal
+import team.b2.bingojango.global.util.EntityFinder
 
 @Service
 @Transactional
 class FoodService(
-    private val foodRepository: FoodRepository,
     private val productService: ProductService,
     private val productRepository: ProductRepository,
     private val purchaseService: PurchaseService,
     private val purchaseRepository: PurchaseRepository,
     private val purchaseProductRepository: PurchaseProductRepository,
-    private val refrigeratorRepository: RefrigeratorRepository
+    private val entityFinder: EntityFinder
 ) {
     // [API] 해당 식품을 n개 만큼 공동구매 신청
     fun addFoodToPurchase(userPrincipal: UserPrincipal, refrigeratorId: Long, foodId: Long, count: Int) =
@@ -37,7 +34,7 @@ class FoodService(
                     product = getProduct(foodId, refrigeratorId)
                 )
             )
-            "${getFood(foodId).name} ${count}개가 공동구매 신청되었습니다." // TODO: 추후 분리 예정
+            "${entityFinder.getFood(foodId).name} ${count}개가 공동구매 신청되었습니다." // TODO: 추후 분리 예정
         }
 
     /*
@@ -48,7 +45,7 @@ class FoodService(
      */
     private fun getCurrentPurchase(userPrincipal: UserPrincipal, refrigeratorId: Long) =
         purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ACTIVE }
-            ?: purchaseService.makePurchase(userPrincipal, getRefrigerator(refrigeratorId))
+            ?: purchaseService.makePurchase(userPrincipal, entityFinder.getRefrigerator(refrigeratorId))
 
     /*
         [내부 메서드] 현재 냉장고에 해당 식품이 Product (상품)으로 등록되어 있는지 여부를 확인
@@ -56,20 +53,15 @@ class FoodService(
             - 해당 Product 가 없다면, 새로운 Product 객체를 생성 후 리턴
      */
     private fun getProduct(foodId: Long, refrigeratorId: Long): Product =
-        productRepository.findByFoodAndRefrigerator(getFood(foodId), getRefrigerator(refrigeratorId))
-            ?: productService.addProduct(getFood(foodId), getRefrigerator(refrigeratorId))
+        productRepository.findByFoodAndRefrigerator(
+            entityFinder.getFood(foodId),
+            entityFinder.getRefrigerator(refrigeratorId)
+        )
+            ?: productService.addProduct(entityFinder.getFood(foodId), entityFinder.getRefrigerator(refrigeratorId))
 
     /*
         [내부 메서드] 현재 공동구매 진행 중인 식품은 공동구매 목록에 추가할 수 없음을 검증
             * TODO : 추후 구현 예정
      */
     private fun checkAlreadyInPurchase() {}
-
-    // [내부 메서드] id로 Food 객체 가져오기
-    private fun getFood(foodId: Long) =
-        foodRepository.findByIdOrNull(foodId) ?: throw Exception("") // TODO
-
-    // [내부 메서드] id로 Refrigerator 객체 가져오기
-    private fun getRefrigerator(refrigeratorId: Long) =
-        refrigeratorRepository.findByIdOrNull(refrigeratorId) ?: throw Exception("") // TODO
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/repository/MemberRepository.kt
@@ -4,10 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import team.b2.bingojango.domain.member.model.Member
 import team.b2.bingojango.domain.member.model.MemberRole
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.domain.user.model.User
 
 @Repository
 interface MemberRepository : JpaRepository<Member, Long> {
     fun countByRole(role: MemberRole): Long
-    fun findByUser(user: User): Member?
+    fun findByUserAndRefrigerator(user: User, refrigerator: Refrigerator): Member?
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/dto/response/PurchaseResponse.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/dto/response/PurchaseResponse.kt
@@ -1,0 +1,16 @@
+package team.b2.bingojango.domain.purchase.dto.response
+
+import team.b2.bingojango.domain.member.model.Member
+import team.b2.bingojango.domain.purchase_product.dto.response.PurchaseProductResponse
+
+data class PurchaseResponse(
+    val memberNickName: String,
+    val purchaseProductList: List<PurchaseProductResponse>
+) {
+    companion object {
+        fun from(member: Member, purchaseProductList: List<PurchaseProductResponse>) = PurchaseResponse(
+            memberNickName = member.user.nickname,
+            purchaseProductList = purchaseProductList
+        )
+    }
+}

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/repository/PurchaseRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/repository/PurchaseRepository.kt
@@ -3,6 +3,7 @@ package team.b2.bingojango.domain.purchase.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import team.b2.bingojango.domain.purchase.model.Purchase
+import team.b2.bingojango.domain.purchase.model.PurchaseStatus
 
 @Repository
 interface PurchaseRepository : JpaRepository<Purchase, Long> {

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
@@ -5,17 +5,14 @@ import org.springframework.transaction.annotation.Transactional
 import team.b2.bingojango.domain.member.model.MemberRole
 import team.b2.bingojango.domain.member.repository.MemberRepository
 import team.b2.bingojango.domain.purchase.dto.response.PurchaseResponse
-import team.b2.bingojango.domain.purchase.model.Purchase
 import team.b2.bingojango.domain.purchase.model.PurchaseStatus
 import team.b2.bingojango.domain.purchase.repository.PurchaseRepository
 import team.b2.bingojango.domain.purchase_product.dto.response.PurchaseProductResponse
 import team.b2.bingojango.domain.purchase_product.repository.PurchaseProductRepository
-import team.b2.bingojango.domain.refrigerator.model.Refrigerator
-import team.b2.bingojango.domain.user.repository.UserRepository
 import team.b2.bingojango.domain.vote.dto.request.VoteRequest
-import team.b2.bingojango.domain.vote.dto.response.VoteResponse
-import team.b2.bingojango.domain.vote.model.Vote
 import team.b2.bingojango.domain.vote.repository.VoteRepository
+import team.b2.bingojango.global.exception.cases.DuplicatedVoteException
+import team.b2.bingojango.global.exception.cases.InvalidRoleException
 import team.b2.bingojango.global.exception.cases.NoCurrentPurchaseException
 import team.b2.bingojango.global.security.UserPrincipal
 import team.b2.bingojango.global.util.EntityFinder
@@ -42,76 +39,52 @@ class PurchaseService(
 
     /*
         [API] 현재 공동구매 목록에 대한 투표 시작
-            - TODO : 공동구매를 신청한 사람만 투표를 시작할 수 있음
-            - TODO : 현재 ACTIVE 한 공동구매가 없는 경우 투표가 진행되지 않음
+            - 검증 조건 1: 공동구매를 신청한 회원 본인만 투표를 시작할 수 있음
+            - 검증 조건 2: STAFF 의 수가 1명인 경우, 투표 과정을 생략하고 현재 Purchase 의 status 를 FINISHED 로 변경
      */
-    fun startVote(userPrincipal: UserPrincipal, refrigeratorId: Long, voteRequest: VoteRequest): VoteResponse {
-        return VoteResponse.from(
-            vote = entityFinder.getMember(userPrincipal.id, refrigeratorId).let {
-                voteRepository.save(
-                    voteRequest.to(
-                        request = voteRequest,
-                        refrigerator = entityFinder.getRefrigerator(refrigeratorId),
-                        member = it
-                    )
-                )
-            },
-            member = entityFinder.getMember(userPrincipal.id, refrigeratorId),
-            numberOfStaff = getNumberOfStaff()
+    fun startVote(userPrincipal: UserPrincipal, refrigeratorId: Long, voteRequest: VoteRequest) {
+        if (getCurrentPurchase().proposedBy != userPrincipal.id) throw InvalidRoleException()
+        else if (getNumberOfStaff() == 1L) getCurrentPurchase().updateStatus(PurchaseStatus.FINISHED)
+        else voteRepository.save(
+            voteRequest.to(
+                request = voteRequest,
+                refrigerator = entityFinder.getRefrigerator(refrigeratorId),
+                member = entityFinder.getMember(userPrincipal.id, refrigeratorId)
+            )
         )
     }
 
     /*
         [API] 투표 실시
-            - 찬성인 경우, voters 에 해당 Member 객체를 add
-            - 만장일치가 완성된 경우, 투표를 종료하고 현재 ACTIVE 상태의 Purchase 를 FINISHED 로 변경
-            - 반대가 하나라도 있는 경우, 투표를 종료하고 현재 ACTIVE 상태의 Purchase 를 REJECTED 로 변경
-            * TODO : 해당 멤버가 투표 권한이 있는지 확인
+            - 검증 조건 1: 관리자(STAFF)만 투표를 할 수 있음
+            - 검증 조건 2: 이미 투표한 경우, 투표 결과를 수정할 수 없음
+            - 검증 조건 3-1: 찬성에 투표한 경우, voters 에 해당 Member 객체를 add
+            - 검증 조건 3-2: 만장일치가 완성된 경우, 투표를 종료하고 현재 Purchase 의 status 를 FINISHED 로 변경
+            - 검증 조건 4: 반대에 투표한 경우, 투표를 종료하고 현재 Purchase 의 status 를 REJECTED 로 변경
      */
     fun vote(userPrincipal: UserPrincipal, refrigeratorId: Long, voteId: Long, isAccepted: Boolean) {
-        entityFinder.getVote(voteId).let {
-            if (isAccepted) {
-                it.vote(entityFinder.getMember(userPrincipal.id, refrigeratorId))
-                if (isCompletedVote(it))
-                    getCurrentPurchase(userPrincipal, refrigeratorId).updateStatus(PurchaseStatus.FINISHED)
-            } else
-                getCurrentPurchase(userPrincipal, refrigeratorId).updateStatus(PurchaseStatus.REJECTED)
-        }
+        entityFinder.getMember(userPrincipal.id, refrigeratorId)
+            .let {
+                if (it.role != MemberRole.STAFF)
+                    throw InvalidRoleException()
+                else if (entityFinder.getVote(voteId).voters.contains(it))
+                    throw DuplicatedVoteException()
+                else entityFinder.getVote(voteId).let { vote ->
+                    if (isAccepted) {
+                        vote.updateVote(entityFinder.getMember(userPrincipal.id, refrigeratorId))
+                        if (getNumberOfStaff() == vote.voters.size.toLong())
+                            getCurrentPurchase().updateStatus(PurchaseStatus.FINISHED)
+                    } else
+                        getCurrentPurchase().updateStatus(PurchaseStatus.REJECTED)
+                }
+            }
     }
-
-    // [내부 메서드] Purchase 객체 생성 (FoodService > getCurrentPurchase 에서만 사용되는 메서드)
-    fun makePurchase(userPrincipal: UserPrincipal, refrigerator: Refrigerator) =
-        purchaseRepository.save(
-            Purchase(
-                status = PurchaseStatus.ACTIVE,
-                proposedBy = userPrincipal.id,
-                refrigerator = refrigerator
-            )
-        )
-
-    // [내부 메서드] 만장일치를 받았는지 확인 (냉장고 내 관리자의 수 == 찬성한 인원 수)
-    private fun isCompletedVote(vote: Vote) =
-        getNumberOfStaff() == vote.voters.size.toLong()
 
     // [내부 메서드] 현재 Refrigerator 내 관리자(STAFF) 의 수
     private fun getNumberOfStaff() = memberRepository.countByRole(MemberRole.STAFF)
 
-    /*
-        [내부 메서드] 현재 진행 중인 Purchase (공동구매)를 리턴
-            - status 가 ACTIVE 인 Purchase 를 리턴
-            - status 가 ACTIVE 인 Purchase 가 없다면, 예외 처ㅣㄹ
-     */
+    // [내부 메서드] 현재 진행 중인(status 가 ACTIVE 한) Purchase 를 리턴 (없으면 예외 처리)
     private fun getCurrentPurchase() =
         purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ACTIVE }
             ?: throw NoCurrentPurchaseException()
-
-    /*
-    [내부 메서드] 현재 진행 중인 Purchase (공동구매)를 리턴
-        - status 가 ACTIVE (투표 진행중) 인 Purchase 확인
-        - status 가 ACTIVE (투표 진행중) 인 Purchase 가 없다면, 새로운 Purchase 객체를 생성 후 리턴
-        * TODO : 추후 조회 과정 리팩토링 필요
-    */
-    private fun getCurrentPurchase(userPrincipal: UserPrincipal, refrigeratorId: Long) =
-        purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ACTIVE }
-            ?: makePurchase(userPrincipal, entityFinder.getRefrigerator(refrigeratorId))
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
@@ -1,60 +1,65 @@
 package team.b2.bingojango.domain.purchase.service
 
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.b2.bingojango.domain.member.model.MemberRole
 import team.b2.bingojango.domain.member.repository.MemberRepository
+import team.b2.bingojango.domain.purchase.dto.response.PurchaseResponse
 import team.b2.bingojango.domain.purchase.model.Purchase
 import team.b2.bingojango.domain.purchase.model.PurchaseStatus
 import team.b2.bingojango.domain.purchase.repository.PurchaseRepository
 import team.b2.bingojango.domain.purchase_product.dto.response.PurchaseProductResponse
 import team.b2.bingojango.domain.purchase_product.repository.PurchaseProductRepository
 import team.b2.bingojango.domain.refrigerator.model.Refrigerator
-import team.b2.bingojango.domain.refrigerator.repository.RefrigeratorRepository
 import team.b2.bingojango.domain.user.repository.UserRepository
 import team.b2.bingojango.domain.vote.dto.request.VoteRequest
 import team.b2.bingojango.domain.vote.dto.response.VoteResponse
 import team.b2.bingojango.domain.vote.model.Vote
 import team.b2.bingojango.domain.vote.repository.VoteRepository
+import team.b2.bingojango.global.exception.cases.NoCurrentPurchaseException
 import team.b2.bingojango.global.security.UserPrincipal
+import team.b2.bingojango.global.util.EntityFinder
 
 @Service
 @Transactional
 class PurchaseService(
-    private val userRepository: UserRepository,
     private val memberRepository: MemberRepository,
     private val purchaseRepository: PurchaseRepository,
     private val purchaseProductRepository: PurchaseProductRepository,
     private val voteRepository: VoteRepository,
-    private val refrigeratorRepository: RefrigeratorRepository
+    private val entityFinder: EntityFinder
 ) {
     // [API] 현재 진행 중인 Purchase 목록을 출력
-    // TODO : 추후 조회 과정 리팩토링 필요
     fun showPurchase(refrigeratorId: Long) =
-        purchaseProductRepository.findAll()
-            .filter { it.purchase.status == PurchaseStatus.ACTIVE }
-            .map { PurchaseProductResponse.from(it) }
+        getCurrentPurchase()
+            .let {
+                PurchaseResponse.from(
+                    member = entityFinder.getMember(it.proposedBy, refrigeratorId),
+                    purchaseProductList = purchaseProductRepository.findAllByPurchase(it)
+                        .map { purchaseProduct -> PurchaseProductResponse.from(purchaseProduct) }
+                )
+            }
 
     /*
         [API] 현재 공동구매 목록에 대한 투표 시작
             - TODO : 공동구매를 신청한 사람만 투표를 시작할 수 있음
             - TODO : 현재 ACTIVE 한 공동구매가 없는 경우 투표가 진행되지 않음
      */
-    fun startVote(userPrincipal: UserPrincipal, refrigeratorId: Long, voteRequest: VoteRequest) =
-        VoteResponse.from(
-            vote = getMember(userPrincipal.id).let {
+    fun startVote(userPrincipal: UserPrincipal, refrigeratorId: Long, voteRequest: VoteRequest): VoteResponse {
+        return VoteResponse.from(
+            vote = entityFinder.getMember(userPrincipal.id, refrigeratorId).let {
                 voteRepository.save(
                     voteRequest.to(
                         request = voteRequest,
-                        refrigerator = getRefrigerator(refrigeratorId),
+                        refrigerator = entityFinder.getRefrigerator(refrigeratorId),
                         member = it
                     )
                 )
             },
-            member = getMember(userPrincipal.id),
+            member = entityFinder.getMember(userPrincipal.id, refrigeratorId),
             numberOfStaff = getNumberOfStaff()
         )
+    }
 
     /*
         [API] 투표 실시
@@ -64,9 +69,9 @@ class PurchaseService(
             * TODO : 해당 멤버가 투표 권한이 있는지 확인
      */
     fun vote(userPrincipal: UserPrincipal, refrigeratorId: Long, voteId: Long, isAccepted: Boolean) {
-        getVote(voteId).let {
+        entityFinder.getVote(voteId).let {
             if (isAccepted) {
-                it.vote(getMember(userPrincipal.id))
+                it.vote(entityFinder.getMember(userPrincipal.id, refrigeratorId))
                 if (isCompletedVote(it))
                     getCurrentPurchase(userPrincipal, refrigeratorId).updateStatus(PurchaseStatus.FINISHED)
             } else
@@ -92,6 +97,15 @@ class PurchaseService(
     private fun getNumberOfStaff() = memberRepository.countByRole(MemberRole.STAFF)
 
     /*
+        [내부 메서드] 현재 진행 중인 Purchase (공동구매)를 리턴
+            - status 가 ACTIVE 인 Purchase 를 리턴
+            - status 가 ACTIVE 인 Purchase 가 없다면, 예외 처ㅣㄹ
+     */
+    private fun getCurrentPurchase() =
+        purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ACTIVE }
+            ?: throw NoCurrentPurchaseException()
+
+    /*
     [내부 메서드] 현재 진행 중인 Purchase (공동구매)를 리턴
         - status 가 ACTIVE (투표 진행중) 인 Purchase 확인
         - status 가 ACTIVE (투표 진행중) 인 Purchase 가 없다면, 새로운 Purchase 객체를 생성 후 리턴
@@ -99,17 +113,5 @@ class PurchaseService(
     */
     private fun getCurrentPurchase(userPrincipal: UserPrincipal, refrigeratorId: Long) =
         purchaseRepository.findAll().firstOrNull { it.status == PurchaseStatus.ACTIVE }
-            ?: makePurchase(userPrincipal, getRefrigerator(refrigeratorId))
-
-    private fun getVote(voteId: Long) =
-        voteRepository.findByIdOrNull(voteId) ?: throw Exception("") // TODO
-
-    private fun getMember(userId: Long) =
-        memberRepository.findByUser(getUser(userId)) ?: throw Exception("") // TODO
-
-    private fun getUser(userId: Long) =
-        userRepository.findByIdOrNull(userId) ?: throw Exception("") // TODO
-
-    private fun getRefrigerator(refrigeratorId: Long) =
-        refrigeratorRepository.findByIdOrNull(refrigeratorId) ?: throw Exception("") // TODO
+            ?: makePurchase(userPrincipal, entityFinder.getRefrigerator(refrigeratorId))
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase_product/dto/response/PurchaseProductResponse.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase_product/dto/response/PurchaseProductResponse.kt
@@ -3,7 +3,6 @@ package team.b2.bingojango.domain.purchase_product.dto.response
 import team.b2.bingojango.domain.purchase_product.model.PurchaseProduct
 
 data class PurchaseProductResponse(
-    // TODO : 추후 공동구매를 신청한 회원의 이름도 리턴 예정
     val foodName: String,
     val foodCount: Int
 ) {

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase_product/repository/PurchaseProductRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase_product/repository/PurchaseProductRepository.kt
@@ -2,8 +2,10 @@ package team.b2.bingojango.domain.purchase_product.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import team.b2.bingojango.domain.purchase.model.Purchase
 import team.b2.bingojango.domain.purchase_product.model.PurchaseProduct
 
 @Repository
 interface PurchaseProductRepository : JpaRepository<PurchaseProduct, Long> {
+    fun findAllByPurchase(purchase: Purchase): List<PurchaseProduct>
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/dto/response/VoteResponse.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/dto/response/VoteResponse.kt
@@ -14,7 +14,7 @@ data class VoteResponse(
         fun from(vote: Vote, member: Member, numberOfStaff: Long) = VoteResponse(
             description = vote.description ?: "",
             dueDate = ZonedDateTimeConverter.convertZonedDateTimeFromStringDateTime(vote.dueDate),
-            memberName = "제안자: ${member.user.nickname}",
+            memberName = member.user.nickname,
             voteStatus = "투표 현황: 찬성 ${vote.voters.size}명 / ${numberOfStaff}명"
         )
     }

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/dto/response/VoteResponse.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/dto/response/VoteResponse.kt
@@ -15,7 +15,7 @@ data class VoteResponse(
             description = vote.description ?: "",
             dueDate = ZonedDateTimeConverter.convertZonedDateTimeFromStringDateTime(vote.dueDate),
             memberName = member.user.nickname,
-            voteStatus = "투표 현황: 찬성 ${vote.voters.size}명 / ${numberOfStaff}명"
+            voteStatus = "${vote.voters.size} / $numberOfStaff"
         )
     }
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/model/Vote.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/model/Vote.kt
@@ -19,14 +19,14 @@ class Vote(
     val refrigerator: Refrigerator,
 
     @ManyToMany
-    val voters: MutableSet<Member> = mutableSetOf()
+    val voters: MutableSet<Member>
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "food_id", nullable = false)
     val id: Long? = null
 
-    fun vote(member: Member) {
+    fun updateVote(member: Member) {
         voters.add(member)
     }
 }

--- a/src/main/kotlin/team/b2/bingojango/global/exception/cases/DuplicatedVoteException.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/cases/DuplicatedVoteException.kt
@@ -1,0 +1,3 @@
+package team.b2.bingojango.global.exception.cases
+
+class DuplicatedVoteException : RuntimeException("이미 투표에 참여하셨습니다.")

--- a/src/main/kotlin/team/b2/bingojango/global/exception/cases/InvalidRoleException.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/cases/InvalidRoleException.kt
@@ -1,0 +1,3 @@
+package team.b2.bingojango.global.exception.cases
+
+class InvalidRoleException : RuntimeException("실행 권한이 없습니다.")

--- a/src/main/kotlin/team/b2/bingojango/global/exception/cases/NoCurrentPurchaseException.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/cases/NoCurrentPurchaseException.kt
@@ -1,0 +1,3 @@
+package team.b2.bingojango.global.exception.cases
+
+class NoCurrentPurchaseException : RuntimeException("현재 진행 중인 공동구매가 없습니다.")

--- a/src/main/kotlin/team/b2/bingojango/global/util/EntityFinder.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/util/EntityFinder.kt
@@ -1,0 +1,39 @@
+package team.b2.bingojango.global.util
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.b2.bingojango.domain.food.repository.FoodRepository
+import team.b2.bingojango.domain.member.repository.MemberRepository
+import team.b2.bingojango.domain.refrigerator.repository.RefrigeratorRepository
+import team.b2.bingojango.domain.user.repository.UserRepository
+import team.b2.bingojango.domain.vote.repository.VoteRepository
+import team.b2.bingojango.global.exception.cases.ModelNotFoundException
+
+@Service
+@Transactional
+class EntityFinder(
+    private val refrigeratorRepository: RefrigeratorRepository,
+    private val memberRepository: MemberRepository,
+    private val userRepository: UserRepository,
+    private val foodRepository: FoodRepository,
+    private val voteRepository: VoteRepository,
+) {
+    fun getRefrigerator(refrigeratorId: Long) =
+        refrigeratorRepository.findByIdOrNull(refrigeratorId) ?: throw ModelNotFoundException("냉장고")
+
+    fun getMember(userId: Long, refrigeratorId: Long) =
+        memberRepository.findByUserAndRefrigerator(
+            user = getUser(userId),
+            refrigerator = getRefrigerator(refrigeratorId)
+        ) ?: throw ModelNotFoundException("멤버")
+
+    fun getUser(userId: Long) =
+        userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("유저")
+
+    fun getFood(foodId: Long) =
+        foodRepository.findByIdOrNull(foodId) ?: throw ModelNotFoundException("식품")
+
+    fun getVote(voteId: Long) =
+        voteRepository.findByIdOrNull(voteId) ?: throw ModelNotFoundException("투표")
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #39

## 작업 내용

- [ ] id를 통해 특정 엔티티를 찾는 메서드들을 하나의 EntityFinder 서비스 클래스로 분리 
    - MemberRepository의 findByUser 메서드를 findByUserAndRefrigerator로 수정
    (전자의 경우, User가 2개 이상의 Refrigerator에 속해 있는 경우 오류가 발생)
- [ ] 예외 케이스 3건 추가
    - NoCurrentPurchaseException : 현재 ACTIVE한 Purchase가 존재하지 않는 경우
    - DuplicatedVoteException : 이미 투표를 한 인원이 다시 투표를 한 경우
    - InvalidRoleException : 특정 기능을 실행할 권한이 없는 경우
- [ ] ACTIVE 한 Purchase를 찾는 방식 변경
    - PurchaseProductRepository에 findAllByPurchase 메서드 추가
- [ ] 불필요한 메서드 및 주석 제거

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
