### PR TITLE
[Refactor] 다른 관리자가 시작한 공동구매가 존재하는 경우, 추가적인 공동구매를 신청할 수 없는 로직 구현

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/repository/PurchaseRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/repository/PurchaseRepository.kt
@@ -7,4 +7,5 @@ import team.b2.bingojango.domain.purchase.model.PurchaseStatus
 
 @Repository
 interface PurchaseRepository : JpaRepository<Purchase, Long> {
+    fun existsByStatus(status: PurchaseStatus): Boolean
 }

--- a/src/main/kotlin/team/b2/bingojango/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/GlobalExceptionHandler.kt
@@ -51,6 +51,11 @@ class GlobalExceptionHandler(
     fun handleInvalidRoleException(e: InvalidCredentialException) =
         ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(getErrorResponse(HttpStatus.UNAUTHORIZED, e))
 
+    // 현재 진행 중인 공동구매가 존재
+    @ExceptionHandler(AlreadyHaveActivePurchaseException::class)
+    fun handleAlreadyHaveActivePurchaseException(e: AlreadyHaveActivePurchaseException) =
+        ResponseEntity.badRequest().body(getErrorResponse(HttpStatus.BAD_REQUEST, e))
+
     // 현재 진행 중인 공동구매 없음
     @ExceptionHandler(NoCurrentPurchaseException::class)
     fun handleNoCurrentPurchaseException(e: NoCurrentPurchaseException) =

--- a/src/main/kotlin/team/b2/bingojango/global/exception/cases/AlreadyHaveActivePurchaseException.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/cases/AlreadyHaveActivePurchaseException.kt
@@ -1,0 +1,3 @@
+package team.b2.bingojango.global.exception.cases
+
+class AlreadyHaveActivePurchaseException: RuntimeException("이미 진행 중인 공동구매가 존재합니다.")


### PR DESCRIPTION
## 연관된 이슈

- closes #66 

## 작업 내용

- [ ] ACTIVE한 Purchase가 있고, 그 Purchase의 proposedBy가 userPrincipal.id와 다른 경우 예외 처리
    - PurchaseRepository에 existsByStatus 메서드 추가
- [ ] 예외 케이스 1건 추가
    - AlreadyHaveActivePurchaseException : 이미 진행 중인 공동구매가 존재하는데 추가적인 공동구매를 신청한 경우

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
