### PR TITLE
[Refactor] 공동구매 목록에 물품이 아무것도 없는 경우 투표가 불가능하게 막는 검증 로직 구현

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
@@ -32,10 +32,10 @@ class PurchaseService(
     private val entityFinder: EntityFinder
 ) {
     /*
-    [API] 해당 식품을 n개 만큼 공동구매 신청
-        - 검증 조건 1 : 관리자(STAFF)만 공동구매를 신청할 수 있음
-        - 검증 조건 2 : 현재 공동구매 중인 식품은 추가할 수 없음
-*/
+        [API] 해당 식품을 n개 만큼 공동구매 신청
+            - 검증 조건 1 : 관리자(STAFF)만 공동구매를 신청할 수 있음
+            - 검증 조건 2 : 현재 공동구매 중인 식품은 추가할 수 없음
+    */
     fun addFoodToPurchase(userPrincipal: UserPrincipal, refrigeratorId: Long, foodId: Long, count: Int) =
         getCurrentPurchase(userPrincipal, refrigeratorId).let {
             if (entityFinder.getMember(userPrincipal.id, refrigeratorId).role != MemberRole.STAFF)
@@ -58,8 +58,8 @@ class PurchaseService(
 
     /*
         [API] 공동구매 목록에서 특정 식품 삭제
-            - 검증 조건 1: 해당 공동구매를 올린 사람만 삭제를 할 수 있음
-            - 검증 조건 2: 현재 공동구매에 존재하는 식품만 삭제할 수 있음
+            - 검증 조건 1 : 해당 공동구매를 올린 사람만 삭제를 할 수 있음
+            - 검증 조건 2 : 현재 공동구매에 존재하는 식품만 삭제할 수 있음
      */
     fun deleteFoodFromPurchase(userPrincipal: UserPrincipal, refrigeratorId: Long, foodId: Long) {
         if (getCurrentPurchase().proposedBy != userPrincipal.id)
@@ -85,11 +85,13 @@ class PurchaseService(
 
     /*
         [API] 현재 공동구매 목록에 대한 투표 시작
-            - 검증 조건 1: 공동구매를 신청한 회원 본인만 투표를 시작할 수 있음
-            - 검증 조건 2: STAFF 의 수가 1명인 경우, 투표 과정을 생략하고 현재 Purchase 의 status 를 FINISHED 로 변경
+            - 검증 조건 1 : 공동구매를 신청한 회원 본인만 투표를 시작할 수 있음
+            - 검증 조건 2 : 공동구매 목록에 물품이 존재하지 않는 경우, 투표를 시작할 수 없음
+            - 검증 조건 3 : STAFF 의 수가 1명인 경우, 투표 과정을 생략하고 현재 Purchase 의 status 를 FINISHED 로 변경
      */
     fun startVote(userPrincipal: UserPrincipal, refrigeratorId: Long, voteRequest: VoteRequest) {
         if (getCurrentPurchase().proposedBy != userPrincipal.id) throw InvalidRoleException()
+        else if (purchaseProductRepository.findAllByPurchase(getCurrentPurchase()).isEmpty()) throw UnableToStartVoteException()
         else if (getNumberOfStaff() == 1L) getCurrentPurchase().updateStatus(PurchaseStatus.FINISHED)
 
         voteRepository.save(

--- a/src/main/kotlin/team/b2/bingojango/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/GlobalExceptionHandler.kt
@@ -61,6 +61,11 @@ class GlobalExceptionHandler(
     fun handleAlreadyInPurchaseException(e: AlreadyInPurchaseException) =
         ResponseEntity.badRequest().body(getErrorResponse(HttpStatus.BAD_REQUEST, e))
 
+    // 공동구매 목록 안에 식품이 없는 상태에서 투표 시작
+    @ExceptionHandler(UnableToStartVoteException::class)
+    fun handleUnableToStartVoteException(e: UnableToStartVoteException) =
+        ResponseEntity.badRequest().body(getErrorResponse(HttpStatus.BAD_REQUEST, e))
+
     // 중복 투표
     @ExceptionHandler(DuplicatedVoteException::class)
     fun handleDuplicatedVoteException(e: DuplicatedVoteException) =

--- a/src/main/kotlin/team/b2/bingojango/global/exception/cases/UnableToStartVoteException.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/cases/UnableToStartVoteException.kt
@@ -1,0 +1,3 @@
+package team.b2.bingojango.global.exception.cases
+
+class UnableToStartVoteException : RuntimeException("공동구매 목록에 식품이 없어서 투표를 진행할 수 없습니다.")


### PR DESCRIPTION
## 연관된 이슈

- closes #68 

## 작업 내용

- [ ] 현재 Purchase에 해당하는 purchaseProduct이 없는 경우 예외 처리
- [ ] 예외 케이스 1건 추가
    - UnableToStartVoteException : 공동구매 목록에 물품이 아무것도 없는데 투표를 시작한 경우

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
