### PR TITLE
[Refactor] 투표가 시작된 경우 해당 공동구매 목록에 음식을 추가/수정/삭제가 불가능하도록 검증하는 로직 구현

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/vote/dto/request/VoteRequest.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/dto/request/VoteRequest.kt
@@ -3,6 +3,7 @@ package team.b2.bingojango.domain.vote.dto.request
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import team.b2.bingojango.domain.member.model.Member
+import team.b2.bingojango.domain.purchase.model.Purchase
 import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.domain.vote.model.Vote
 import team.b2.bingojango.global.util.ZonedDateTimeConverter
@@ -17,10 +18,11 @@ data class VoteRequest(
     )
     val dueDate: String,
 ) {
-    fun to(request: VoteRequest, refrigerator: Refrigerator, member: Member) = Vote(
+    fun to(request: VoteRequest, refrigerator: Refrigerator, member: Member, purchase: Purchase) = Vote(
         description = request.description,
         dueDate = ZonedDateTimeConverter.convertStringDateTimeFromZonedDateTime(request.dueDate),
         refrigerator = refrigerator,
-        voters = mutableSetOf(member)
+        voters = mutableSetOf(member),
+        purchase = purchase
     )
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/model/Vote.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/model/Vote.kt
@@ -2,6 +2,7 @@ package team.b2.bingojango.domain.vote.model
 
 import jakarta.persistence.*
 import team.b2.bingojango.domain.member.model.Member
+import team.b2.bingojango.domain.purchase.model.Purchase
 import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.global.entity.BaseEntity
 import java.time.ZonedDateTime
@@ -15,7 +16,12 @@ class Vote(
     @Column(name = "due_date", nullable = false)
     val dueDate: ZonedDateTime,
 
+    @OneToOne
+    @JoinColumn(name = "purchase_id")
+    val purchase: Purchase,
+
     @ManyToOne
+    @JoinColumn(name = "refrigerator_id")
     val refrigerator: Refrigerator,
 
     @ManyToMany

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/repository/VoteRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/repository/VoteRepository.kt
@@ -2,8 +2,11 @@ package team.b2.bingojango.domain.vote.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import team.b2.bingojango.domain.purchase.model.Purchase
+import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.domain.vote.model.Vote
 
 @Repository
 interface VoteRepository : JpaRepository<Vote, Long> {
+    fun existsByPurchaseAndRefrigerator(purchase: Purchase, refrigerator: Refrigerator): Boolean
 }

--- a/src/main/kotlin/team/b2/bingojango/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/GlobalExceptionHandler.kt
@@ -71,6 +71,11 @@ class GlobalExceptionHandler(
     fun handleUnableToStartVoteException(e: UnableToStartVoteException) =
         ResponseEntity.badRequest().body(getErrorResponse(HttpStatus.BAD_REQUEST, e))
 
+    // 투표가 이미 진행 중인 공동구매에 대한 식품 추가/수정/삭제 시도
+    @ExceptionHandler(AlreadyOnVoteException::class)
+    fun handleAlreadyOnVoteException(e: AlreadyOnVoteException) =
+        ResponseEntity.badRequest().body(getErrorResponse(HttpStatus.BAD_REQUEST, e))
+
     // 중복 투표
     @ExceptionHandler(DuplicatedVoteException::class)
     fun handleDuplicatedVoteException(e: DuplicatedVoteException) =

--- a/src/main/kotlin/team/b2/bingojango/global/exception/cases/AlreadyOnVoteException.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/cases/AlreadyOnVoteException.kt
@@ -1,0 +1,3 @@
+package team.b2.bingojango.global.exception.cases
+
+class AlreadyOnVoteException(value: String) : RuntimeException("이미 구매 여부에 대한 투표가 시작되어 식품을 ${value}할 수 없습니다.")


### PR DESCRIPTION
## 연관된 이슈

- closes #82 

## 작업 내용

- [ ] addFoodToPurchase, updateFoodInPurchase, deleteFoodFromPurchase 메서드에 검증 로직 추가
- [ ] Vote와 Purchase 엔티티를 1:1 연관관계로 설정
- [ ] VoteRepository에 Purchase와 Refrigerator 객체로 Vote를 찾는 existsByPurchaseAndRefrigerator 메서드 생성
- [ ] 예외 케이스 1건 추가
    - AlreadyOnVoteException : 투표가 시작된 상황에서 음식을 추가/수정/삭제하는 경우

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
