### PR TITLE
[Feat] 지금까지 진행된 모든 공동구매 목록을 조회

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/controller/PurchaseController.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/controller/PurchaseController.kt
@@ -2,7 +2,6 @@ package team.b2.bingojango.domain.purchase.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
-import org.apache.coyote.Response
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
@@ -44,12 +43,26 @@ class PurchaseController(
     ) =
         ResponseEntity.ok().body(purchaseService.deleteFoodFromPurchase(userPrincipal, refrigeratorId, foodId))
 
-    @Operation(summary = "현재 공동구매 목록을 출력")
+    @Operation(summary = "현재 진행 중인 공동구매를 출력")
     @GetMapping
     fun showPurchase(
         @PathVariable refrigeratorId: Long
     ) =
         purchaseService.showPurchase(refrigeratorId)
+
+    @Operation(summary = "현재까지 진행된 모든 공동구매 목록을 출력")
+    @GetMapping("/all")
+    fun showPurchaseList(
+        @PathVariable refrigeratorId: Long
+    ) = purchaseService.showPurchaseList(refrigeratorId)
+
+    @Operation(summary = "완료/거절된 이전 공동구매를 선택 후 똑같은 내용의 공동구매 생성")
+    @PostMapping("/{purchaseId}")
+    fun copyPurchase(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable refrigeratorId: Long,
+        @PathVariable purchaseId: Long
+    ) = purchaseService.copyPurchase(userPrincipal, refrigeratorId, purchaseId)
 
     @Operation(summary = "현재 공동구매 목록에 대한 투표 현황 조회")
     @GetMapping("/vote/{voteId}")

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/dto/response/PurchaseResponse.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/dto/response/PurchaseResponse.kt
@@ -1,16 +1,21 @@
 package team.b2.bingojango.domain.purchase.dto.response
 
 import team.b2.bingojango.domain.member.model.Member
+import team.b2.bingojango.domain.purchase.model.Purchase
+import team.b2.bingojango.domain.purchase.model.PurchaseStatus
 import team.b2.bingojango.domain.purchase_product.dto.response.PurchaseProductResponse
 
 data class PurchaseResponse(
     val memberNickName: String,
+    val status: PurchaseStatus,
     val purchaseProductList: List<PurchaseProductResponse>
 ) {
     companion object {
-        fun from(member: Member, purchaseProductList: List<PurchaseProductResponse>) = PurchaseResponse(
-            memberNickName = member.user.nickname,
-            purchaseProductList = purchaseProductList
-        )
+        fun from(purchase: Purchase, member: Member, purchaseProductList: List<PurchaseProductResponse>) =
+            PurchaseResponse(
+                memberNickName = member.user.nickname,
+                status = purchase.status,
+                purchaseProductList = purchaseProductList
+            )
     }
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/model/Vote.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/model/Vote.kt
@@ -16,6 +16,7 @@ class Vote(
     val dueDate: ZonedDateTime,
 
     @ManyToOne
+    @JoinColumn(name = "refrigerator_id")
     val refrigerator: Refrigerator,
 
     @ManyToMany
@@ -23,7 +24,7 @@ class Vote(
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "food_id", nullable = false)
+    @Column(name = "vote_id", nullable = false)
     val id: Long? = null
 
     fun updateVote(member: Member) {


### PR DESCRIPTION
## 연관된 이슈

- closes #85 

## 작업 내용

- [ ] PurchaseController와 PurchaseService에 showPurchaseList 메서드 추가 (모든 공동구매 목록 조회)
- [ ] PurchaseController와 PurchaseService에 copyPurchase 메서드 추가 (이전 공동구매와 같은 내용으로 담기)
- [ ] PurchaseResponse에 status 속성 추가
- [ ] Vote 엔티티에 id 컬럼명을 vote_id로 정정

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
