### PR TITLE
[Refactor] Vote 관련 API에서 votedId가 굳이 필요 없는 경우 파라미터에서 제거

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/vote/controller/VoteController.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/controller/VoteController.kt
@@ -15,12 +15,11 @@ class VoteController(
     private val voteService: VoteService
 ) {
     @Operation(summary = "현재 공동구매 목록에 대한 투표 현황 조회")
-    @GetMapping("/{voteId}")
+    @GetMapping
     fun showVote(
-        @PathVariable refrigeratorId: Long,
-        @PathVariable voteId: Long
+        @PathVariable refrigeratorId: Long
     ) =
-        ResponseEntity.ok().body(voteService.showVote(refrigeratorId, voteId))
+        ResponseEntity.ok().body(voteService.showVote(refrigeratorId))
 
     @Operation(summary = "현재 공동구매 목록에 대한 투표 시작")
     @PostMapping
@@ -32,12 +31,11 @@ class VoteController(
         ResponseEntity.ok().body(voteService.startVote(userPrincipal, refrigeratorId, voteRequest))
 
     @Operation(summary = "현재 공동구매 목록에 대한 투표")
-    @PutMapping("/{voteId}")
+    @PutMapping
     fun vote(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PathVariable refrigeratorId: Long,
-        @PathVariable voteId: Long,
         @RequestParam isAccepted: Boolean
     ) =
-        ResponseEntity.ok().body(voteService.vote(userPrincipal, refrigeratorId, voteId, isAccepted))
+        ResponseEntity.ok().body(voteService.vote(userPrincipal, refrigeratorId, isAccepted))
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/repository/VoteRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/repository/VoteRepository.kt
@@ -9,4 +9,6 @@ import team.b2.bingojango.domain.vote.model.Vote
 @Repository
 interface VoteRepository : JpaRepository<Vote, Long> {
     fun existsByPurchaseAndRefrigerator(purchase: Purchase, refrigerator: Refrigerator): Boolean
+
+    fun findByPurchase(purchase: Purchase): Vote?
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/vote/service/VoteService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/vote/service/VoteService.kt
@@ -10,10 +10,7 @@ import team.b2.bingojango.domain.purchase_product.repository.PurchaseProductRepo
 import team.b2.bingojango.domain.vote.dto.request.VoteRequest
 import team.b2.bingojango.domain.vote.dto.response.VoteResponse
 import team.b2.bingojango.domain.vote.repository.VoteRepository
-import team.b2.bingojango.global.exception.cases.DuplicatedVoteException
-import team.b2.bingojango.global.exception.cases.InvalidRoleException
-import team.b2.bingojango.global.exception.cases.NoCurrentPurchaseException
-import team.b2.bingojango.global.exception.cases.UnableToStartVoteException
+import team.b2.bingojango.global.exception.cases.*
 import team.b2.bingojango.global.security.UserPrincipal
 import team.b2.bingojango.global.util.EntityFinder
 
@@ -27,9 +24,9 @@ class VoteService(
     private val entityFinder: EntityFinder
 ) {
     // [API] 현재 공동구매 목록에 대한 투표 현황 조회
-    fun showVote(refrigeratorId: Long, voteId: Long) =
+    fun showVote(refrigeratorId: Long) =
         VoteResponse.from(
-            vote = entityFinder.getVote(voteId),
+            vote = voteRepository.findByPurchase(getCurrentPurchase()) ?: throw NoCurrentVoteException(),
             member = entityFinder.getMember(
                 userId = getCurrentPurchase().proposedBy,
                 refrigeratorId = refrigeratorId
@@ -68,22 +65,23 @@ class VoteService(
             - 검증 조건 3-2 : 만장일치가 완성된 경우, 투표를 종료하고 현재 Purchase 의 status 를 APPROVED 로 변경
             - 검증 조건 4 : 반대에 투표한 경우, 투표를 종료하고 현재 Purchase 의 status 를 REJECTED 로 변경
      */
-    fun vote(userPrincipal: UserPrincipal, refrigeratorId: Long, voteId: Long, isAccepted: Boolean) =
+    fun vote(userPrincipal: UserPrincipal, refrigeratorId: Long, isAccepted: Boolean) =
         entityFinder.getMember(userPrincipal.id, refrigeratorId)
             .let {
                 if (it.role != MemberRole.STAFF)
                     throw InvalidRoleException()
-                else if (entityFinder.getVote(voteId).voters.contains(it))
-                    throw DuplicatedVoteException()
+                else if (voteRepository.findByPurchase(getCurrentPurchase())?.voters?.contains(it)
+                        ?: throw NoCurrentVoteException()
+                ) throw DuplicatedVoteException()
 
-                entityFinder.getVote(voteId).let { vote ->
+                voteRepository.findByPurchase(getCurrentPurchase())?.let { vote ->
                     if (isAccepted) {
                         vote.updateVote(entityFinder.getMember(userPrincipal.id, refrigeratorId))
                         if (getNumberOfStaff() == vote.voters.size.toLong())
                             getCurrentPurchase().updateStatus(PurchaseStatus.APPROVED)
                     } else
                         getCurrentPurchase().updateStatus(PurchaseStatus.REJECTED)
-                }
+                } ?: throw NoCurrentVoteException()
             }
 
     // [내부 메서드] 현재 진행 중인(status 가 ACTIVE 한) Purchase 를 리턴 (없으면 예외 처리)

--- a/src/main/kotlin/team/b2/bingojango/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/GlobalExceptionHandler.kt
@@ -66,6 +66,11 @@ class GlobalExceptionHandler(
     fun handleAlreadyInPurchaseException(e: AlreadyInPurchaseException) =
             ResponseEntity.badRequest().body(getErrorResponse(HttpStatus.BAD_REQUEST, e))
 
+    // 현재 진행 중인 투표 없음
+    @ExceptionHandler(NoCurrentVoteException::class)
+    fun handleNoCurrentVoteException(e: NoCurrentVoteException) =
+        ResponseEntity.badRequest().body(getErrorResponse(HttpStatus.BAD_REQUEST, e))
+
     // 공동구매 목록 안에 식품이 없는 상태에서 투표 시작
     @ExceptionHandler(UnableToStartVoteException::class)
     fun handleUnableToStartVoteException(e: UnableToStartVoteException) =

--- a/src/main/kotlin/team/b2/bingojango/global/exception/cases/NoCurrentVoteException.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/exception/cases/NoCurrentVoteException.kt
@@ -1,0 +1,3 @@
+package team.b2.bingojango.global.exception.cases
+
+class NoCurrentVoteException : RuntimeException("현재 진행 중인 투표가 없습니다.")


### PR DESCRIPTION
## 연관된 이슈

- closes #97 

## 작업 내용

- [ ] showVote, vote 메서드에서 voteId를 파라미터로 받지 않음
- [ ] vote 객체를 조회할 때 voteId가 아닌 purchase를 활용하여 조회
    - VoteRepository에 findByPurchase 메서드 생성
- [ ] 예외 케이스 1건 추가 (NoCurrentVoteException)
    - 특정 Purchase에 대해서 Vote 가 진행중이 아닌데 Vote를 조회하는 경우

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
