### PR TITLE
[BugFix] 같이구매 내 상품(PurchaseProduct)을 가져오는 메서드 수정

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase/service/PurchaseService.kt
@@ -81,9 +81,10 @@ class PurchaseService(
             )
         ) throw AlreadyOnVoteException("삭제")
 
-        (purchaseProductRepository.findByRefrigeratorAndProduct(
+        (purchaseProductRepository.findByRefrigeratorAndProductAndPurchase(
             refrigerator = entityFinder.getRefrigerator(refrigeratorId),
-            product = getProduct(foodId, refrigeratorId)
+            product = getProduct(foodId, refrigeratorId),
+            purchase = getCurrentPurchase()
         ) ?: throw ModelNotFoundException("식품")).updateCount(count)
     }
 
@@ -103,9 +104,10 @@ class PurchaseService(
         ) throw AlreadyOnVoteException("삭제")
 
         purchaseProductRepository.delete(
-            purchaseProductRepository.findByRefrigeratorAndProduct(
+            purchaseProductRepository.findByRefrigeratorAndProductAndPurchase(
                 refrigerator = entityFinder.getRefrigerator(refrigeratorId),
-                product = getProduct(foodId, refrigeratorId)
+                product = getProduct(foodId, refrigeratorId),
+                purchase = getCurrentPurchase()
             ) ?: throw ModelNotFoundException("식품")
         )
     }

--- a/src/main/kotlin/team/b2/bingojango/domain/purchase_product/repository/PurchaseProductRepository.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/purchase_product/repository/PurchaseProductRepository.kt
@@ -11,5 +11,5 @@ import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 interface PurchaseProductRepository : JpaRepository<PurchaseProduct, Long> {
     fun findAllByPurchase(purchase: Purchase): List<PurchaseProduct>
 
-    fun findByRefrigeratorAndProduct(refrigerator: Refrigerator, product: Product): PurchaseProduct?
+    fun findByRefrigeratorAndProductAndPurchase(refrigerator: Refrigerator, product: Product, purchase: Purchase): PurchaseProduct?
 }


### PR DESCRIPTION
## 연관된 이슈

- closes #107 

## 작업 내용

- [ ] PurchaseProductRepository에 PurchaseProduct를 가져올 때 purcahse도 검증
    - findByRefrigeratorAndProduct 메서드를 findByRefrigeratorAndProductAndPurchase 메서드로 수정
    - PurchaseService 관련 코드 수정

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
