### PR TITLE
[Refactor] 서버 배포 준비를 위한 프로젝트 코드 일부 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,4 @@ out
 gen
 build
 .gradle
-application.yml
+application-local.yml

--- a/src/main/kotlin/team/b2/bingojango/global/home/HomeController.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/home/HomeController.kt
@@ -1,0 +1,10 @@
+package team.b2.bingojango.global.home
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HomeController {
+    @GetMapping("/")
+    fun home() = "Hello, Bingo!" // TODO : 추후 수정
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-server.port=80

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=80

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,39 @@
+# Server-Port
+server:
+  port: 80
+
+spring:
+  # SLACK
+  profiles:
+    include: slack
+
+  # Mail
+  mail:
+    host: ${MAIL_HOST}
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: ${MAIL_CONNECTION_TIMEOUT}
+          timeout: ${MAIL_TIMEOUT}
+          writetimeout: ${MAIL_WRITE_TIMEOUT}
+    auth-code-expiration-millis: ${MAIL_AUTH_CODE_EXPIRATION_MILLIS}
+
+# JWT
+auth:
+  jwt:
+    issuer: ${JWT_ISSUER}
+    secret: ${JWT_SECRET}
+    accessTokenExpirationHour: ${JWT_ACCESS_TOKEN_EXPIRATION_HOUR}
+    refreshTokenExpirationHour: ${JWT_REFRESH_TOKEN_EXPIRATION_HOUR}
+
+# SLACK
+slack:
+  bot-token: ${SLACK_BOT_TOKEN}
+  channel: ${SLACK_CHANNEL}


### PR DESCRIPTION
## 연관된 이슈

- closes #113 

## 작업 내용

- [ ] 서버의 기본 포트를 80번으로 설정
- [ ] 루트(/) 경로 설정
- [ ] application.yml 파일 업로드 (환경 분리: 서버와 로컬에 필요한 설정을 각각 별도의 yml 파일로 분리)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
