### PR TITLE
[Refactor] 냉장고 및 음식에 부족한 로직 추가

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/food/controller/FoodController.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/controller/FoodController.kt
@@ -81,7 +81,7 @@ class FoodController(
         sort: SortFood?,
         category: FoodCategory?,
         count: Int?,
-        keyword: String
+        keyword: String?
     ): ResponseEntity<Page<FoodResponse>> {
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/main/kotlin/team/b2/bingojango/domain/food/repository/FoodRepositoryImpl.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/repository/FoodRepositoryImpl.kt
@@ -27,6 +27,7 @@ class FoodRepositoryImpl: QueryDslSupport(), CustomFoodRepository {
         val whereClause = BooleanBuilder()
         val pageable: PageRequest = PageRequest.of(page, 10, Sort.by(sort.toString()))
 
+        refrigeratorId.let { whereClause.and(food.refrigerator.id.eq(refrigeratorId)) }
         category?.let { whereClause.and(food.category.eq(category)) } //카테고리와 동일한 음식
         count?.let { whereClause.and(food.count.loe(count))} //count 이하 갯수의 음식
         keyword?.let { whereClause.and(food.name.contains(keyword)) } //검색어를 포함한 음식

--- a/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/food/service/FoodService.kt
@@ -119,6 +119,8 @@ class FoodService(
         count: Int?,
         keyword: String?
     ): Page<FoodResponse> {
+        val refrigerator = refrigeratorRepository.findByIdOrNull(refrigeratorId) ?: throw ModelNotFoundException("Refrigerator")
+        if (refrigerator.status != RefrigeratorStatus.NORMAL) {throw ModelNotFoundException("Refrigerator")}
         return foodRepository.findByFood(refrigeratorId, page, sort, category, count, keyword).map { it.toResponse() }
     }
 }

--- a/src/main/kotlin/team/b2/bingojango/domain/refrigerator/service/RefrigeratorService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/refrigerator/service/RefrigeratorService.kt
@@ -16,6 +16,7 @@ import team.b2.bingojango.domain.refrigerator.dto.response.RefrigeratorResponse
 import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.domain.refrigerator.model.RefrigeratorStatus
 import team.b2.bingojango.domain.refrigerator.repository.RefrigeratorRepository
+import team.b2.bingojango.domain.user.model.QUser.user
 import team.b2.bingojango.domain.user.repository.UserRepository
 import team.b2.bingojango.global.exception.cases.DuplicateValueException
 import team.b2.bingojango.global.exception.cases.ModelNotFoundException
@@ -41,6 +42,7 @@ class RefrigeratorService(
     @Transactional
     fun addRefrigerator(userPrincipal: UserPrincipal, request: AddRefrigeratorRequest): RefrigeratorResponse {
         if (refrigeratorRepository.existsRefrigeratorByName(request.name)) throw DuplicateValueException("중복된 냉장고 이름 입니다.")
+        if (request.password != request.rePassword) throw IllegalArgumentException("비밀번호와 비밀번호확인이 일치하지 않습니다.")
         val user = userRepository.findByIdOrNull(userPrincipal.id) ?: throw ModelNotFoundException("User")
         val refrigerator = refrigeratorRepository.save(Refrigerator.toEntity(request))
         val chatRoom = chatRoomService.buildChatRoom(refrigerator, userPrincipal)

--- a/src/main/kotlin/team/b2/bingojango/domain/refrigerator/service/RefrigeratorService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/refrigerator/service/RefrigeratorService.kt
@@ -16,7 +16,6 @@ import team.b2.bingojango.domain.refrigerator.dto.response.RefrigeratorResponse
 import team.b2.bingojango.domain.refrigerator.model.Refrigerator
 import team.b2.bingojango.domain.refrigerator.model.RefrigeratorStatus
 import team.b2.bingojango.domain.refrigerator.repository.RefrigeratorRepository
-import team.b2.bingojango.domain.user.model.QUser.user
 import team.b2.bingojango.domain.user.repository.UserRepository
 import team.b2.bingojango.global.exception.cases.DuplicateValueException
 import team.b2.bingojango.global.exception.cases.ModelNotFoundException


### PR DESCRIPTION
## 연관된 이슈
- closes #184 

## 작업 내용
- 냉장고 생성 시 비밀번호와 비밀번호확인이 다를 경우 예외처리가 되어있지 않아 예외를 추가했습니다.
- 음식 검색 시, refrigeratorId에 따른 음식이 조회되도록  수정했습니다.

