### PR TITLE
[Refactor] OAuth2 이메일 중복 검사 추가

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/user/model/User.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/model/User.kt
@@ -16,13 +16,13 @@ class User(
     @Column(name = "name", nullable = true)
     var name: String?,
 
-    @Column(name = "nickname", nullable = false)
+    @Column(name = "nickname", nullable = false, unique = true)
     var nickname: String,
 
     @Column(name = "phone", nullable = true)
     var phone: String?,
 
-    @Column(name = "email", nullable = false)
+    @Column(name = "email", nullable = false, unique = true)
     var email: String,
 
     @Column(name = "password", nullable = true)

--- a/src/main/kotlin/team/b2/bingojango/domain/user/model/User.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/model/User.kt
@@ -16,7 +16,7 @@ class User(
     @Column(name = "name", nullable = true)
     var name: String?,
 
-    @Column(name = "nickname", nullable = false, unique = true)
+    @Column(name = "nickname", nullable = false)
     var nickname: String,
 
     @Column(name = "phone", nullable = true)

--- a/src/main/kotlin/team/b2/bingojango/global/oauth/api/oauth2login/service/SocialMemberService.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/oauth/api/oauth2login/service/SocialMemberService.kt
@@ -14,7 +14,7 @@ class SocialMemberService(
     // OAuth2LoginUserInfo를 회원가입 시키는 역할
     fun registerIfAbsent(userInfo: OAuth2LoginUserInfo): User {
         return if (!userRepository.existsByProviderAndProviderId(userInfo.provider, userInfo.id)) {
-            if (userRepository.existsByEmail(userInfo.email)) throw IllegalArgumentException("이미 가입된 이메일입니다.")
+            if (userRepository.existsByEmail(userInfo.email)) throw IllegalArgumentException("이미 사용 중인 이메일입니다.")
             val user = User(
                 role = UserRole.USER,
                 name = null,

--- a/src/main/kotlin/team/b2/bingojango/global/oauth/api/oauth2login/service/SocialMemberService.kt
+++ b/src/main/kotlin/team/b2/bingojango/global/oauth/api/oauth2login/service/SocialMemberService.kt
@@ -14,6 +14,7 @@ class SocialMemberService(
     // OAuth2LoginUserInfo를 회원가입 시키는 역할
     fun registerIfAbsent(userInfo: OAuth2LoginUserInfo): User {
         return if (!userRepository.existsByProviderAndProviderId(userInfo.provider, userInfo.id)) {
+            if (userRepository.existsByEmail(userInfo.email)) throw IllegalArgumentException("이미 가입된 이메일입니다.")
             val user = User(
                 role = UserRole.USER,
                 name = null,


### PR DESCRIPTION
## 연관된 이슈
- closes #233

## 작업 내용
- 이미 다른 경로로 가입된 이메일이 있을 경우 계정이 생성되지 않도록 예외처리 추가.
