### PR TITLE
[Refactor] MemberResponse 에 img, userId 추가

### DIFF
--- a/src/main/kotlin/team/b2/bingojango/domain/member/dto/MemberResponse.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/dto/MemberResponse.kt
@@ -1,11 +1,14 @@
 package team.b2.bingojango.domain.member.dto
 
 import team.b2.bingojango.domain.member.model.MemberRole
+import team.b2.bingojango.domain.user.model.User
 import java.time.ZonedDateTime
 
 data class MemberResponse(
     val name: String,
     val role: MemberRole,
     val memberId: Long,
-    val createdAt: ZonedDateTime
+    val createdAt: ZonedDateTime,
+    val imageUrl: String?,
+    val userId: Long,
 )

--- a/src/main/kotlin/team/b2/bingojango/domain/member/dto/MemberResponse.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/dto/MemberResponse.kt
@@ -1,7 +1,6 @@
 package team.b2.bingojango.domain.member.dto
 
 import team.b2.bingojango.domain.member.model.MemberRole
-import team.b2.bingojango.domain.user.model.User
 import java.time.ZonedDateTime
 
 data class MemberResponse(

--- a/src/main/kotlin/team/b2/bingojango/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/member/service/MemberService.kt
@@ -38,7 +38,9 @@ class MemberService(
                 name = member.user.nickname,
                 role = member.role,
                 memberId = member.id!!,
-                createdAt = member.createdAt
+                createdAt = member.createdAt,
+                imageUrl = member.user.image,
+                userId = member.user.id!!,
             )
         }
     }

--- a/src/main/kotlin/team/b2/bingojango/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/team/b2/bingojango/domain/user/controller/UserController.kt
@@ -98,7 +98,7 @@ class UserController(
     @PatchMapping("/change/profile")
     fun updateProfile(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
-        @RequestBody profileUpdateRequest: ProfileUpdateRequest
+        @RequestBody @Valid profileUpdateRequest: ProfileUpdateRequest
     ): ResponseEntity<String> {
         userService.updateProfile(userPrincipal, profileUpdateRequest)
         return ResponseEntity.status(HttpStatus.OK).build()


### PR DESCRIPTION
## 연관된 이슈
- closes #287 

## 작업 내용
- 멤버목록에 이미지 반환을 위하여 userId 와 userImage를 포함해서 response 하는 것으로 로직 변경함.
